### PR TITLE
Improvement on the /ns content

### DIFF
--- a/vocab/ODRL22.html
+++ b/vocab/ODRL22.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>ODRL Version 2.2 Ontology</title>
+	<link rel="stylesheet" type="text/css" href="//www.w3.org/StyleSheets/TR/base">
+	<link rel="alternate" type="text/turtle" href="ODRL22.ttl">
+	<link rel="alternate" type="application/rdf+xml" href="ODRL22.rdf">
+	<link rel="alternate" type="application/xml" href="ODRL22.xsd">
+	<link rel="alternate" type="text/plain" href="ODRL22.nt">
+	<link rel="alternate" type="application/json" href="ODRL22.json">	
+</head>
+<body>
+	<div class="head">
+		<p>
+			<a href="http://www.w3.org/"><img width="72" height="48" alt="W3C" src="http://www.w3.org/Icons/w3c_home"/></a>
+		</p>
+		<h1>ODRL Version 2.2 Ontology</h1>
+	</div>
+	<p>
+		<em>The Open Digital Rights Language (ODRL) is a policy expression language that provides a flexible and interoperable information model, vocabulary, and encoding mechanisms for representing statements about the usage of content and services. The ODRL Vocabulary and Expression describes the terms used in ODRL policies and how to encode them.</em>					
+	</p>
+	<dl>
+		<dt>This version</dt><dd><a href="http://www.w3.org/ns/odrl/2/ODRL22">http://www.w3.org/ns/odrl/2/ODRL22</a></dd>
+		<dt>Latest version</dt><dd><a href="http://www.w3.org/ns/odrl/2/">http://www.w3.org/ns/odrl/2/</a></dd>
+		<dt>Date</dt><dd>2017-09-16</dd>
+		<dt>Revision</dt><dd>2.2</dd>
+		<dt>Authors</dt><dd>Renato Ianella, Michael Steidl, Stuart Myles, Víctor Rodrigues-Doncel</dd>
+		<dt>Contributors</dt><dd>PO&amp;E Working Group</dd>
+	</dl>
+
+	<h2 id="sec-status">Status of this document</h2>
+
+	<p>
+		This vocabulary was published by the <a href="https://www.w3.org/2016/poe/">Permissions &amp; Obligations Expression Working Group</a>. See the full <a href="https://www.w3.org/TR/odrl-vocab/">ODRL Vocabulary &amp; Expression</a> specification for a detailed, human readable version of the vocabulary, as well as the <a href="https://www.w3.org/TR/odrl-model/">ODRL Information Model</a> specification describing the underlying model.
+	</p>
+
+	<h2 id="sec-ns">Namespace URI</h2>
+	<p>
+		The namespace URI for ODRL is <a href="http://www.w3.org/ns/odrl/2/"><code>http://www.w3.org/ns/odrl/2/</code></a>.
+	</p>
+	<h2 id="sec-alternates">Alternative serialisations</h2>
+	<p>
+		The ODRL 2 vocabulary is published both in human- and machine-readable forms. A <code>GET</code> request made to the canonical namespace URI will cause <a href="http://www.w3.org/blog/2006/02/content-negotiation/">HTTP Content Negotiation</a> to occur, which means that the most appropriate variant will be served according to your request. However, if you explicitly wish to retrieve a particular serialisation, you can also do so using the following URLs:
+	</p>
+	<dl>
+		<dt><a href="ODRL22.html">ODRL22.html</a></dt>
+		<dd>HTML (this document)</dd>
+
+		<dt><a href="ODRL22.ttl">ODRL22.ttl</a></dt>
+		<dd>RDF (Turtle)</dd>
+
+		<dt><a href="ODRL22.rdf">ODRL22.rdf</a></dt>
+		<dd>RDF/XML</dd>
+		
+		<dt><a href="ODRL22.nt">ODRL22.nt</a></dt>
+		<dd>RDF (N-Triples)</dd>
+		
+		<dt><a href="ODRL22.xsd">ODRL22.xsd</a></dt>
+		<dd>XML Schema Definition</dd>
+
+		<dt><a href="ODRL22.json">ODRL22.json</a></dt>
+		<dd>JSON Schema Definition</dd>
+	</dl>
+</body>
+</html>

--- a/vocab/ODRL22.html
+++ b/vocab/ODRL22.html
@@ -25,8 +25,8 @@
 		<dt>Latest version</dt><dd><a href="http://www.w3.org/ns/odrl/2/">http://www.w3.org/ns/odrl/2/</a></dd>
 		<dt>Date</dt><dd>2017-09-16</dd>
 		<dt>Revision</dt><dd>2.2</dd>
-		<dt>Authors</dt><dd>Renato Ianella, Michael Steidl, Stuart Myles, Víctor Rodrigues-Doncel</dd>
-		<dt>Contributors</dt><dd>PO&amp;E Working Group</dd>
+		<dt>Authors</dt><dd>Renato Iannella, Michael Steidl, Stuart Myles, Víctor Rodríguez-Doncel</dd>
+		<dt>Contributors</dt><dd>W3C POE Working Group</dd>
 	</dl>
 
 	<h2 id="sec-status">Status of this document</h2>
@@ -57,7 +57,7 @@
 		<dd>RDF (N-Triples)</dd>
 		
 		<dt><a href="ODRL22.xsd">ODRL22.xsd</a></dt>
-		<dd>XML Schema Definition</dd>
+		<dd>XML Schema Definition (Non-normative)</dd>
 
 		<dt><a href="ODRL22.json">ODRL22.json</a></dt>
 		<dd>JSON Schema Definition</dd>

--- a/vocab/ODRL22.nt
+++ b/vocab/ODRL22.nt
@@ -1,0 +1,2281 @@
+@base <http://www.w3.org/ns/odrl/2/> .
+@prefix : <http://www.w3.org/ns/odrl/2/> .
+@prefix odrl: <http://www.w3.org/ns/odrl/2/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix schema: <http://schema.org/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix vcard: <http://www.w3.org/2006/vcard/ns#> .
+@prefix cc: <http://creativecommons.org/ns#> .
+
+odrl:
+	a owl:Ontology ;
+	rdfs:label "ODRL Version 2.2"@en ;
+	owl:versionInfo "2.2" ;
+	dct:creator "Mo McRoberts", "Renato Iannella", "Michael Steidl", "Stuart Myles", "Víctor Rodríguez-Doncel" ;
+	dct:contributor "W3C Permissions & Obligations Expression Working Group" ;
+	dct:description "The ODRL Vocabulary and Expression defines a set of concepts and terms (the vocabulary) and encoding mechanism (the expression) for permissions and obligations statements describing digital content usage based on the ODRL Information Model."@en ;
+	rdfs:comment "This is the RDF ontology for ODRL Version 2.2 (working draft)."@en ;
+	dct:license <https://www.w3.org/Consortium/Legal/2002/ipr-notice-20021231#Copyright/> .
+
+
+## SKOS Collections for Grouping related concepts.
+## These SKOS Collections are primarily used to create the
+## sections of the ODRL Vocabulary document.
+
+<http://www.w3.org/ns/odrl/2/#policyConcepts>
+    a skos:Collection ;
+    skos:prefLabel "Policy"@en ;
+    skos:scopeNote "ODRL Core Vocabulary Terms"@en ;
+    skos:member :Policy ;
+    skos:member :uid ;
+    skos:member :profile ;
+    skos:member :inheritFrom .
+
+<http://www.w3.org/ns/odrl/2/#ruleConcepts>
+    a skos:Collection ;
+    skos:prefLabel "Rule"@en ;
+    skos:scopeNote "ODRL Core Vocabulary Terms"@en ;
+    skos:member :Rule ;
+    skos:member :relation ;
+    skos:member :function ;
+    skos:member :failure .
+
+<http://www.w3.org/ns/odrl/2/#conflictConcepts>
+    a skos:Collection ;
+    skos:prefLabel "Policy Conflict Strategy"@en ;
+    skos:scopeNote "ODRL Core Vocabulary Terms"@en ;
+    skos:member :ConflictTerm ;
+    skos:member :conflict ;
+    skos:member :perm ;
+    skos:member :prohibit ;
+    skos:member :invalid .
+
+
+<http://www.w3.org/ns/odrl/2/#policySubClasses>
+    a skos:Collection ;
+    skos:prefLabel "Policy Subclasses"@en ;
+    skos:scopeNote "ODRL Core Vocabulary Terms"@en ;
+    skos:member :Agreement ;
+    skos:member :Offer ;
+    skos:member :Set .
+
+<http://www.w3.org/ns/odrl/2/#policySubClassesCommon>
+    a skos:Collection ;
+    skos:prefLabel "Policy Subclasses"@en ;
+    skos:scopeNote "ODRL Common Vocabulary Terms"@en ;
+    skos:member :Assertion ;
+    skos:member :Privacy ;
+    skos:member :Request ;
+    skos:member :Ticket .
+
+<http://www.w3.org/ns/odrl/2/#assetConcepts>
+    a skos:Collection ;
+    skos:prefLabel "Asset"@en ;
+    skos:scopeNote "ODRL Core Vocabulary Terms"@en ;
+    skos:member :Asset ;
+    skos:member :AssetCollection ;
+    skos:member :partOf ;
+    skos:member :source .
+
+<http://www.w3.org/ns/odrl/2/#assetRelations>
+    a skos:Collection ;
+    skos:prefLabel "Asset Relations"@en ;
+    skos:scopeNote "ODRL Core Vocabulary Terms"@en ;
+    skos:member :target ;
+    skos:member :hasPolicy .
+
+<http://www.w3.org/ns/odrl/2/#assetRelationsCommon>
+    a skos:Collection ;
+    skos:prefLabel "Asset Relations"@en ;
+    skos:scopeNote "ODRL Common Vocabulary Terms"@en ;
+    skos:member :output .
+
+
+<http://www.w3.org/ns/odrl/2/#partyConcepts>
+    a skos:Collection ;
+    skos:prefLabel "Party"@en ;
+    skos:scopeNote "ODRL Core Vocabulary Terms"@en ;
+    skos:member :Party ;
+    skos:member :PartyCollection ;
+    skos:member :partOf ;
+    skos:member :source .
+
+<http://www.w3.org/ns/odrl/2/#partyRoles>
+    a skos:Collection ;
+    skos:prefLabel "Party Functions"@en ;
+    skos:scopeNote "ODRL Core Vocabulary Terms"@en ;
+    skos:member :assignee ;
+    skos:member :assigner ;
+    skos:member :assigneeOf ;
+    skos:member :assignerOf .
+
+
+<http://www.w3.org/ns/odrl/2/#partyRolesCommon>
+    a skos:Collection ;
+    skos:prefLabel "Party Functions"@en ;
+    skos:scopeNote "ODRL Common Vocabulary Terms"@en ;
+    skos:member :attributedParty ;
+    skos:member :attributingParty ;
+    skos:member :compensatedParty ;
+    skos:member :compensatingParty ;
+    skos:member :consentingParty ;
+    skos:member :consentedParty ;
+    skos:member :contractingParty ;
+    skos:member :contractedParty ;
+    skos:member :informedParty ;
+    skos:member :informingParty ;
+    skos:member :trackingParty ;
+    skos:member :trackedParty .
+
+
+<http://www.w3.org/ns/odrl/2/#actionConcepts>
+    a skos:Collection ;
+    skos:prefLabel "Action"@en ;
+    skos:scopeNote "ODRL Core Vocabulary Terms"@en ;
+    skos:member :Action ;
+    skos:member :action ;
+    skos:member :includedIn ;
+    skos:member :implies .
+
+<http://www.w3.org/ns/odrl/2/#permissions>
+    a skos:Collection ;
+    skos:prefLabel "Permission"@en ;
+    skos:scopeNote "ODRL Core Vocabulary Terms"@en ;
+    skos:member :Permission ;
+    skos:member :permission .
+
+<http://www.w3.org/ns/odrl/2/#prohibitions>
+    a skos:Collection ;
+    skos:prefLabel "Prohibition"@en ;
+    skos:scopeNote "ODRL Core Vocabulary Terms"@en ;
+    skos:member :Prohibition ;
+    skos:member :prohibition .
+
+<http://www.w3.org/ns/odrl/2/#actions>
+    a skos:Collection ;
+    skos:prefLabel "Actions for Rules"@en ;
+    skos:scopeNote "ODRL Core Vocabulary Terms"@en ;
+    skos:member :use ;
+    skos:member :transfer .
+
+<http://www.w3.org/ns/odrl/2/#actionsCommon>
+    a skos:Collection ;
+    skos:prefLabel "Actions for Rules"@en ;
+    skos:scopeNote "ODRL Common Vocabulary Terms"@en ;
+    skos:member :acceptTracking ;
+    skos:member :aggregate ;
+    skos:member :annotate ;
+    skos:member :anonymize ;
+    skos:member :archive ;
+    skos:member :attribute ;
+    skos:member cc:Attribution ;
+    skos:member cc:CommericalUse ;
+    skos:member :compensate ;
+    skos:member :concurrentUse ;
+    skos:member :delete ;
+    skos:member :derive ;
+    skos:member cc:DerivativeWorks ;
+    skos:member :digitize ;
+    skos:member :display ;
+    skos:member :distribute ;
+    skos:member cc:Distribution ;
+    skos:member :ensureExclusivity ;
+    skos:member :execute ;
+    skos:member :extract ;
+    skos:member :give ;
+    skos:member :grantUse ;
+    skos:member :include ;
+    skos:member :index ;
+    skos:member :inform ;
+    skos:member :install ;
+    skos:member :modify ;
+    skos:member :move ;
+    skos:member :nextPolicy ;
+    skos:member cc:Notice ;
+    skos:member :obtainConsent ;
+    skos:member :play ;
+    skos:member :present ;
+    skos:member :print ;
+    skos:member :read ;
+    skos:member :reproduce ;
+    skos:member cc:Reproduction ;
+    skos:member :reviewPolicy ;
+    skos:member :sell ;
+    skos:member cc:ShareAlike ;
+    skos:member cc:Sharing ;
+    skos:member cc:SourceCode ;
+    skos:member :stream ;
+    skos:member :synchronize ;
+    skos:member :textToSpeech ;
+    skos:member :transform ;
+    skos:member :translate ;
+    skos:member :uninstall ;
+    skos:member :watermark .
+
+<http://www.w3.org/ns/odrl/2/#duties>
+    a skos:Collection ;
+    skos:prefLabel "Duty"@en ;
+    skos:scopeNote "ODRL Core Vocabulary Terms"@en ;
+    skos:member :Duty ;
+    skos:member :obligation ;
+    skos:member :duty ;
+    skos:member :consequence ;
+    skos:member :remedy .
+
+
+<http://www.w3.org/ns/odrl/2/#constraints>
+    a skos:Collection ;
+    skos:prefLabel "Constraint"@en ;
+    skos:scopeNote "ODRL Core Vocabulary Terms"@en ;
+    skos:member :Constraint ;
+    skos:member :constraint ;
+    skos:member :refinement ;
+    skos:member :Operator ;
+    skos:member :operator ;
+	skos:member :RightOperand ;
+    skos:member :rightOperand ;
+    skos:member :rightOperandReference ;
+	skos:member :LeftOperand ;
+	skos:member :leftOperand ;
+    skos:member :unit ;
+    skos:member :dataType ;
+    skos:member :status .
+
+
+<http://www.w3.org/ns/odrl/2/#logicalConstraints>
+    a skos:Collection ;
+    skos:prefLabel "Logical Constraint"@en ;
+    skos:scopeNote "ODRL Core Vocabulary Terms"@en ;
+    skos:member :LogicalConstraint ;
+    skos:member :operand .
+
+
+<http://www.w3.org/ns/odrl/2/#constraintLeftOperandCommon>
+    a skos:Collection ;
+    skos:prefLabel "Constraint Left Operands"@en ;
+    skos:scopeNote "ODRL Common Vocabulary Terms"@en ;
+    skos:member :absolutePosition ;
+    skos:member :absoluteSpatialPosition ;
+    skos:member :absoluteTemporalPosition ;
+    skos:member :absoluteSize ;
+    skos:member :count ;
+    skos:member :dateTime ;
+    skos:member :delayPeriod ;
+    skos:member :deliveryChannel ;
+    skos:member :elapsedTime ;
+    skos:member :event ;
+    skos:member :fileFormat ;
+    skos:member :industry ;
+    skos:member :language ;
+    skos:member :media ;
+    skos:member :meteredTime ;
+    skos:member :payAmount ;
+    skos:member :percentage ;
+    skos:member :product ;
+    skos:member :purpose ;
+    skos:member :recipient ;
+    skos:member :relativePosition ;
+    skos:member :relativeSpatialPosition ;
+    skos:member :relativeTemporalPosition ;
+    skos:member :relativeSize ;
+    skos:member :resolution ;
+    skos:member :spatial ;
+    skos:member :spatialCoordinates ;
+    skos:member :systemDevice ;
+    skos:member :timeInterval ;
+    skos:member :unitOfCount ;
+    skos:member :version ;
+    skos:member :virtualLocation .
+
+<http://www.w3.org/ns/odrl/2/#constraintLogicalOperands>
+    a skos:Collection ;
+    skos:prefLabel "Logical Constraint Operands"@en ;
+    skos:scopeNote "ODRL Core Vocabulary Terms"@en ;
+    skos:member :or ;
+    skos:member :xone ;
+    skos:member :and ;
+    skos:member :andSequence .
+
+<http://www.w3.org/ns/odrl/2/#constraintRelationalOperators>
+    a skos:Collection ;
+    skos:prefLabel "Constraint Operators"@en ;
+    skos:scopeNote "ODRL Core Vocabulary Terms"@en ;
+    skos:member :eq ;
+    skos:member :gt ;
+    skos:member :gteq ;
+    skos:member :lt ;
+    skos:member :lteq ;
+    skos:member :neq ;
+    skos:member :isA ;
+    skos:member :hasPart ;
+    skos:member :isPartOf ;
+    skos:member :isAllOf ;
+    skos:member :isAnyOf ;
+    skos:member :isNoneOf .
+
+<http://www.w3.org/ns/odrl/2/#constraintRightOpCommon>
+    a skos:Collection ;
+    skos:prefLabel "Constraint Right Operands"@en ;
+    skos:scopeNote "ODRL Common Vocabulary Terms"@en ;
+    skos:member :policyUsage .
+
+
+<http://www.w3.org/ns/odrl/2/#deprecatedTerms>
+    a skos:Collection ;
+    skos:prefLabel "Deprecated Terms"@en ;
+    skos:member :device ;
+    skos:member :system ;
+    skos:member :proximity ;
+    skos:member :append ;
+    skos:member :appendTo ;
+    skos:member :copy ;
+    skos:member :export ;
+    skos:member :lease ;
+    skos:member :license ;
+    skos:member :lend ;
+    skos:member :pay ;
+    skos:member :payeeParty ;
+    skos:member :preview ;
+    skos:member :secondaryUse ;
+    skos:member :write ;
+    skos:member :writeTo ;
+    skos:member :adHocShare ;
+    skos:member :extractChar ;
+    skos:member :extractPage ;
+    skos:member :extractWord ;
+    skos:member :extractWord ;
+    skos:member :timedCount ;
+    skos:member :inheritRelation ;
+    skos:member :inheritAllowed ;
+    skos:member :UndefinedTerm ;
+    skos:member :undefined ;
+    skos:member :ignore ;
+    skos:member :support ;
+    skos:member :AssetScope ;
+    skos:member :PartyScope ;
+    skos:member :scope ;
+    skos:member :Group ;
+    skos:member :Individual ;
+    skos:member :All ;
+    skos:member :AllConnections ;
+    skos:member :All2ndConnections ;
+    skos:member :AllGroups ;
+    skos:member :attachPolicy ;
+    skos:member :attachSource ;
+    skos:member :shareAlike ;
+    skos:member :commercialize ;
+    skos:member :share .
+
+
+## ODRL Core Profile
+
+:core
+	a owl:Thing , skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:label "ODRL Core Profile"@en ;
+	skos:definition "Identifier for the ODRL Core Profile"@en .
+
+## Assets
+
+:Asset
+	a rdfs:Class , owl:Class, skos:Concept;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:label "Asset"@en ;
+	skos:definition "A resource or a collection of resources that are the subject of a Rule."@en ;
+    skos:note "The Asset entity can be any form of identifiable resource, such as data/information, content/media, applications, or services. Furthermore, it can be used to represent other Asset entities that are needed to undertake the Policy expression, such as with the Duty entity. To describe more details about the Asset, it is recommended to use Dublin Core [[dcterms]] elements or other content metadata."@en .
+
+:AssetCollection
+	a rdfs:Class , owl:Class, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:subClassOf :Asset ;
+	rdfs:label "Asset Collection"@en ;
+	skos:definition "An Asset that is collection of individual resources"@en .
+
+:partOf
+	a rdf:Property , owl:ObjectProperty, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:label "Part Of"@en ;
+	skos:definition "Identifies an Asset/PartyCollection that the Asset/Party is a member of."@en ;
+	rdfs:domain [
+		a owl:Class ;
+		owl:unionOf ( :Asset :Party ) ;
+	] ;
+	rdfs:range [
+		a owl:Class ;
+		owl:unionOf ( :AssetCollection :PartyCollection ) ;
+	] .
+
+## Parties
+
+:Party
+	a rdfs:Class , owl:Class, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:label "Party"@en ;
+	skos:definition "An entity or a collection of entities that undertake Roles in a Rule."@en ;
+	rdfs:subClassOf [
+		a owl:Class ;
+		owl:unionOf ( schema:Person schema:Organization foaf:Person foaf:Organization foaf:Agent vcard:Individual vcard:Organization vcard:Agent ) ;
+	];
+	skos:note "The Party entity could be a person, group of people, organisation, or agent. An agent is a person or thing that takes an active role or produces a specified effect. To describe more details about the Party, it is recommended to use W3C vCard Ontology [[vcard-rdf]] or FOAF Vocabulary [[foaf]]."@en .
+
+
+:PartyCollection
+	a rdfs:Class , owl:Class, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:subClassOf :Party ;
+	rdfs:label "Party Collection"@en ;
+	skos:definition "A Party that is a group of individual entities"@en .
+
+## Policies
+
+:Policy
+	a rdfs:Class , owl:Class, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:label "Policy"@en ;
+	skos:definition "A non-empty group of Permissions and/or Prohibitions."@en ;
+	skos:note "A Policy may contain multiple Rules."@en .
+
+:hasPolicy
+	a rdf:Property , owl:ObjectProperty, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:label "Target Policy"@en ;
+	skos:definition "Identifies an ODRL Policy for which the identified Asset is the target Asset to all the Rules."@en ;
+	skos:note "The Asset being identified MUST be inferred to be the target Asset of all of the Rules of the Policy."@en ;
+    rdfs:domain :Asset ;
+	rdfs:range :Policy .
+
+:uid
+	a rdf:Property, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:label "Unique Identifier"@en ;
+	skos:definition "An unambiguous identifier"@en ;
+	skos:note "Used by the Policy, Rule, Asset, and Party Classes."@en ;
+	rdfs:domain [
+		a owl:Class ;
+		owl:unionOf ( :Policy :Asset :Rule :Party ) ;
+	] .
+
+:source
+	a rdf:Property, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:label "Source"@en ;
+	skos:definition "Reference to a Asset/PartyCollection"@en ;
+	skos:note "Used by AssetCollection and PartyCollection when constraints are applied."@en ;
+	rdfs:domain [
+		a owl:Class ;
+		owl:unionOf ( :AssetCollection :PartyCollection ) ;
+	] .
+
+:ConflictTerm
+	a rdfs:Class, owl:Class, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+    skos:definition "Used to establish strategies to resolve conflicts that arise from the merging of Policies or conflicts between Permissions and Prohibitions in the same Policy."@en ;
+    skos:note "Instances of ConflictTerm describe strategies for resolving conflicts."@en ;
+	rdfs:label "Conflict Strategy Preference"@en .
+
+:perm
+	a :ConflictTerm, owl:NamedIndividual, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:label "Prefer Permissions"@en ;
+    skos:definition "Permissions take preference over prohibitions."@en ;
+    skos:note "Used to determine policy conflict outcomes."@en .
+
+:prohibit
+	a :ConflictTerm, owl:NamedIndividual, skos:Concept;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:label "Prefer Prohibitions"@en ;
+    skos:definition "Prohibitions take preference over permissions."@en ;
+	skos:note "Used to determine policy conflict outcomes."@en .
+
+:UndefinedTerm
+	a rdfs:Class, owl:Class, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	skos:definition "Is used to indicate how to support Actions that are not part of any vocabulary or profile in the policy expression system."@en ;
+	skos:note "Instances of UndefinedTerm describe strategies for processing unsupported actions."@en ;
+	rdfs:label "Undefined Term"@en ;
+    owl:deprecated true .
+
+:ignore
+	a :UndefinedTerm, owl:NamedIndividual, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:label "Ignore Undefined Actions"@en ;
+	skos:definition "The Action is to be ignored and is not part of the policy – and the policy remains valid."@en ;
+	skos:note "Used to support actions not known to the policy system."@en ;
+    owl:deprecated true .
+
+:invalid
+	a :ConflictTerm, owl:NamedIndividual, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:label "Void Policy"@en ;
+	skos:definition "The policy is void."@en ;
+	skos:note "Used to indicate the policy is void for Conflict Strategy."@en ;
+    skos:scopeNote "Non-Normative"@en .
+
+:support
+	a :UndefinedTerm, owl:NamedIndividual, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:label "Support Undefined Actions"@en ;
+	skos:definition "The Action is to be supported as part of the policy – and the policy remains valid."@en ;
+	skos:note "Used to support actions not known to the policy system."@en ;
+    owl:deprecated true .
+
+:conflict
+	a rdf:Property , owl:ObjectProperty, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:label "Handle Policy Conflicts"@en ;
+	skos:definition "The conflict-resolution strategy for a Policy."@en ;
+	skos:note "If no strategy is specified, the default is invalid."@en ;
+	rdfs:domain :Policy ;
+	rdfs:range :ConflictTerm .
+
+:undefined
+	a rdf:Property , owl:ObjectProperty, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:label "Handle Undefined Term"@en ;
+	skos:definition "Relates the strategy used for handling undefined actions to a Policy."@en ;
+	skos:note "If no strategy is specified, the default is invalid."@en ;
+	rdfs:range :UndefinedTerm ;
+    owl:deprecated true .
+
+:permission
+	a rdf:Property , owl:ObjectProperty, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:label "Has Permission"@en ;
+	skos:definition "Relates an individual Permission to a Policy."@en ;
+	rdfs:domain :Policy ;
+	rdfs:range :Permission .
+
+:prohibition
+	a rdf:Property , owl:ObjectProperty, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:label "Has Prohibition"@en ;
+	skos:definition "Relates an individual Prohibition to a Policy."@en ;
+	rdfs:domain :Policy ;
+	rdfs:range :Prohibition.
+
+:inheritAllowed
+	a rdf:Property , owl:DatatypeProperty, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:label "Inheritance Allowed"@en ;
+	skos:definition "Indicates if the Policy entity can be inherited."@en ;
+	skos:note "A boolean value."@en ;
+#	rdfs:domain :Policy ;
+#	rdfs:range xsd:boolean .
+    owl:deprecated true .
+
+:inheritFrom
+	a rdf:Property , owl:ObjectProperty, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:label "Inherits From"@en ;
+	skos:definition "Relates a (child) policy to another (parent) policy from which terms are inherited."@en ;
+	skos:note "The child policy will inherit Rules from the parent policy"@en ;
+	rdfs:domain :Policy ;
+	rdfs:range :Policy .
+
+:inheritRelation
+	a rdf:Property , owl:ObjectProperty, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:label "Inherit Relation"@en ;
+	skos:definition "Indentifies the type of inheritance."@en ;
+	skos:note "For example, this may indicate the business scenario, such as subscription, or prior arrangements between the parties (that are not machine representable)."@en ;
+#	rdfs:domain :Policy ;
+#	rdfs:range rdfs:Resource ;
+    owl:deprecated true .
+
+
+:profile
+	a rdf:Property, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:label "Profile"@en ;
+	skos:definition "The identifier(s) of an ODRL Profile that the Policy conforms to."@en ;
+	skos:note "The profile property is mandatory if the Policy is using an ODRL Profile."@en ;
+	rdfs:domain :Policy .
+#	rdfs:range rdfs:Resource .
+
+## Permissions, prohibitions and duties
+
+:Rule
+	a rdfs:Class , owl:Class, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:label "Rule"@en ;
+	skos:definition "An abstract concept that represents the common characteristics of Permissions, Prohibitions, and Duties."@en ;
+	skos:note "Rule is an abstract concept."@en .
+
+:Permission
+	a rdfs:Class , owl:Class, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:subClassOf :Rule ;
+	owl:disjointWith :Prohibition, :Duty ;
+	rdfs:label "Permission"@en ;
+	skos:definition "The ability to perform an Action over an Asset."@en .
+
+:Prohibition
+	a rdfs:Class , owl:Class, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:subClassOf :Rule ;
+	owl:disjointWith :Duty, :Permission ;
+	rdfs:label "Prohibition"@en ;
+	skos:definition "The inability to perform an Action over an Asset."@en .
+
+:Duty
+	a rdfs:Class , owl:Class, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:subClassOf :Rule ;
+	owl:disjointWith :Prohibition, :Permission ;
+	rdfs:label "Duty"@en ;
+    skos:definition "The obligation to perform an Action"@en .
+
+:Action
+	a rdfs:Class, owl:Class, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	skos:definition "An operation on an Asset."@en ;
+	skos:note "Actions may be allowed by Permissions, disallowed by Prohibitions, or made mandatory by Duties."@en ;
+	rdfs:subClassOf schema:Action ;
+	rdfs:label "Action"@en .
+
+:includedIn
+	a rdf:Property, owl:ObjectProperty, owl:SymmetricProperty, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:label "Included In"@en ;
+	skos:definition "An Action transitively asserts that another Action that encompasses its operational semantics."@en ;
+	skos:note "The purpose is to explicitly assert that the semantics of the referenced instance of an other Action encompasses (includes) the semantics of this instance of Action. The includedIn property is transitive, and as such, the Actions form ancestor relationships."@en ;
+	rdfs:domain :Action ;
+	rdfs:range :Action  .
+
+:implies
+	a rdf:Property , owl:ObjectProperty, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:label "Implies"@en ;
+	skos:definition "An Action asserts that another Action is not prohibited to enable its operational semantics."@en ;
+	skos:note "The property asserts that an instance of Action entails that the other instance of Action is not prohibited."@en ;
+	rdfs:domain :Action ;
+	rdfs:range :Action  .
+
+
+:Constraint
+	a rdfs:Class, owl:Class, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:label "Constraint"@en ;
+	skos:definition "A boolean expression that refines the semantics of an Action and Party/Asset Collection or declare the conditions applicable to a Rule."@en .
+
+:LogicalConstraint
+	a rdfs:Class, owl:Class, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:label "Logical Constraint"@en ;
+	skos:definition "A logical expression that refines the semantics of an Action and Party/Asset Collection or declare the conditions applicable to a Rule."@en .
+
+
+:relation
+	a rdf:Property , owl:ObjectProperty, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:label "Relation"@en ;
+	skos:definition "Relation is an abstract property which creates an explicit link between an Action and an Asset."@en ;
+	skos:note "Sub-properties of relation are used to define the nature of that link."@en ;
+	rdfs:domain [
+		a owl:Class ;
+		owl:unionOf ( :Rule :Policy ) ;
+	] ;
+	rdfs:range :Asset .
+
+:output
+	a rdf:Property , owl:ObjectProperty, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:subPropertyOf :relation ;
+	rdfs:label "Output"@en ;
+	skos:definition "The output property specifies the Asset which is created from the output of the Action."@en ;
+	rdfs:domain :Rule ;
+	rdfs:range :Asset  ;
+    skos:scopeNote "Non-Normative"@en .
+
+:target
+	a rdf:Property , owl:ObjectProperty, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:subPropertyOf :relation ;
+	rdfs:label "Target"@en ;
+	skos:definition "The target property indicates the Asset that is the primary subject to which the Rule action directly applies."@en ;
+	rdfs:domain [
+		a owl:Class ;
+		owl:unionOf ( :Rule :Policy ) ;
+	] ;
+	rdfs:range :Asset .
+
+:function
+	a rdf:Property , owl:ObjectProperty, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:label "Function"@en ;
+	skos:definition "Function is an abstract property whose sub-properties define the functional roles which may be fulfilled by a party in relation to a Rule."@en ;
+	rdfs:domain [
+		a owl:Class ;
+		owl:unionOf ( :Rule :Policy ) ;
+	] ;
+	rdfs:range :Party .
+
+:scope
+	a rdf:Property , owl:ObjectProperty, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:label "Scope"@en ;
+	skos:definition "The identifier of a scope that provides context to the extent of the entity."@en ;
+	skos:note "Used to define scopes for Assets and Parties."@en ;
+    owl:deprecated true .
+
+:action
+	a rdf:Property , owl:ObjectProperty, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:label "Has Action"@en ;
+	skos:definition "The operation relating to the Asset for which the Rule is being subjected."@en ;
+	rdfs:domain [
+		a owl:Class ;
+		owl:unionOf ( :Rule :Policy ) ;
+	] ;
+	rdfs:range :Action .
+
+:constraint
+	a rdf:Property , owl:ObjectProperty, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:label "Has Constraint"@en ;
+	skos:definition "Constraint applied to a Rule"@en ;
+	skos:note "Constraints on Rules are used to determine if a rule is Active or not. Example: the Permission rule is only active during the year 2018."@en ;
+	rdfs:domain [
+		a owl:Class ;
+		owl:unionOf ( :Policy :Rule ) ;
+	] ;
+	rdfs:range [
+		a owl:Class ;
+		owl:unionOf ( :Constraint :LogicalConstraint ) ;
+	] .
+
+:refinement
+	a rdf:Property , owl:ObjectProperty, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:label "Refinement"@en ;
+	skos:definition "Constraint used to refine the semantics of an Action, or Party/Asset Collection"@en ;
+	skos:note "Example: the Action print is only permitted on 50% of the asset."@en ;
+	rdfs:domain [
+		a owl:Class ;
+		owl:unionOf ( :Action :AssetCollection :PartyCollection ) ;
+	] ;
+	rdfs:range [
+		a owl:Class ;
+		owl:unionOf ( :Constraint :LogicalConstraint ) ;
+	] .
+
+:duty
+	a rdf:Property , owl:ObjectProperty, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:label "Has Duty"@en ;
+	skos:definition "Relates an individual Duty to a Permission."@en ;
+	skos:note "A Duty is a pre-condition which must be fulfilled in order to receive the Permission."@en ;
+	rdfs:domain :Permission ;
+	rdfs:range :Duty .
+
+:obligation
+	a rdf:Property , owl:ObjectProperty, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:label "Obligation"@en ;
+	skos:definition "Relates an individual Duty to a Policy."@en ;
+	skos:note "The Duty is a requirement which must be fulfilled."@en ;
+	rdfs:domain :Policy ;
+	rdfs:range :Duty .
+
+:failure
+	a rdf:Property , owl:ObjectProperty, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:label "Failure"@en ;
+	skos:definition "Failure is an abstract property that defines the violation (or unmet) relationship between Rules."@en ;
+	skos:note "The parent property to sub-properties that express explicit failure contexts."@en ;
+	rdfs:domain :Rule ;
+	rdfs:range :Rule .
+
+:consequence
+	a rdf:Property , owl:ObjectProperty, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+    rdfs:subPropertyOf :failure ;
+	rdfs:label "Consequence"@en ;
+	skos:definition "Relates a Duty to another Duty, the latter being a consequence of not fulfilling the former."@en ;
+	skos:note "The consequence property is utilised to express the repercussions of not fulfilling an agreed obligation (for a Policy) or duty (for a Permission)."@en ;
+	rdfs:domain :Duty ;
+	rdfs:range :Duty .
+
+:remedy
+	a rdf:Property , owl:ObjectProperty, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+    rdfs:subPropertyOf :failure ;
+	rdfs:label "Remedy"@en ;
+	skos:definition "Relates an individual remedy Duty to a Prohibition."@en ;
+	skos:note "The remedy property expresses an agreed Duty that must be fulfilled in case that a Prohibition has been violated by being exercised."@en ;
+	rdfs:domain :Prohibition ;
+	rdfs:range :Duty .
+
+:unit
+	a rdf:Property ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:domain :Constraint ;
+	rdfs:label "Unit"@en ;
+	skos:definition "The unit of measurement of the value of the rightOperand or rightOperandReference of a Constraint."@en .
+
+:dataType
+	a rdf:Property, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:domain :Constraint ;
+	rdfs:range rdfs:Datatype ;
+	rdfs:label "Datatype"@en ;
+	skos:definition "The datatype of the value of the rightOperand or rightOperandReference of a Constraint."@en ;
+    skos:note "In RDF encodings, use of the rdf:datatype MUST be used. In JSON-LD encoding, the use of @type MUST be used."@en .
+
+:operator
+	a rdf:Property , owl:ObjectProperty, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:label "Has Operator"@en ;
+	skos:definition "The operator function applied to operands of a Constraint"@en ;
+	rdfs:domain :Constraint ;
+	rdfs:range :Operator .
+
+:rightOperand
+	a rdf:Property, owl:DataTypeProperty, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:label "Has Right Operand"@en ;
+	skos:definition "The value of the right operand in a constraint expression."@en ;
+    skos:note "When used with set-based operators, a list of values may be used."@en ;
+	rdfs:range [
+		a owl:Class ;
+		owl:unionOf ( :RightOperand rdfs:Literal xsd:anyURI ) ;
+	] ;
+	rdfs:domain :Constraint .
+
+:rightOperandReference
+	a rdf:Property, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:label "Has Right Operand Reference"@en ;
+	skos:definition "A reference to a web resource providing the value for the right operand of a Constraint."@en ;
+	skos:note "An IRI that MUST be dereferenced to obtain the actual right operand value. When used with set-based operators, a list of IRIs may be used"@en ;
+	rdfs:domain :Constraint .
+
+:leftOperand
+	a rdf:Property, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:label "Has Left Operand"@en ;
+	skos:definition "The left operand in a constraint expression."@en ;
+	rdfs:range :LeftOperand ;
+	rdfs:domain :Constraint .
+
+:status
+	a rdf:Property, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:label "Status"@en ;
+	skos:definition "the value generated from the leftOperand action or a value related to the leftOperand set as the reference for the comparison."@en ;
+	rdfs:domain :Constraint .
+
+:operand
+	a rdf:Property , owl:ObjectProperty, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:label "Operand"@en ;
+	skos:definition "Operand is an abstract property for a logical relationship."@en ;
+	skos:note "Sub-properties of operand are used for Logical Constraints."@en ;
+	rdfs:domain :LogicalConstraint .
+
+## Operators
+
+:Operator
+	a rdfs:Class , owl:Class, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:label "Operator"@en ;
+	skos:definition "Operator for constraint expression."@en ;
+	skos:note "Instances of the Operator class representing relational operators."@en .
+
+:eq
+	a :Operator, owl:NamedIndividual, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:label "Equal to"@en ;
+	skos:definition "Indicating that a given value equals the right operand of the Constraint."@en .
+
+:gt
+	a :Operator, owl:NamedIndividual, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	skos:definition "Indicating that a given value is greater than the right operand of the Constraint."@en ;
+	rdfs:label "Greater than"@en .
+
+:gteq
+	a :Operator, owl:NamedIndividual, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	skos:definition "Indicating that a given value is greater than or equal to the right operand of the Constraint."@en ;
+	rdfs:label "Greater than or equal to"@en .
+
+:hasPart
+	a :Operator, owl:NamedIndividual, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	skos:definition "A set-based operator indicating that a given value contains the right operand of the Constraint."@en ;
+	rdfs:label "Has part"@en .
+
+:isA
+	a :Operator, owl:NamedIndividual, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	skos:definition "A set-based operator indicating that a given value is an instance of the right operand of the Constraint."@en ;
+	rdfs:label "Is a"@en .
+
+:isAllOf
+	a :Operator, owl:NamedIndividual, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	skos:definition "A set-based operator indicating that a given value is all of the right operand of the Constraint."@en ;
+	rdfs:label "Is all of"@en  .
+
+:isAnyOf
+	a :Operator, owl:NamedIndividual, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	skos:definition "A set-based operator indicating that a given value is any of the right operand of the Constraint."@en ;
+	rdfs:label "Is any of"@en .
+
+:isNoneOf
+	a :Operator, owl:NamedIndividual, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	skos:definition "A set-based operator indicating that a given value is none of the right operand of the Constraint."@en ;
+	rdfs:label "Is none of"@en .
+
+:isPartOf
+	a :Operator, owl:NamedIndividual, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	skos:definition "A set-based operator indicating that a given value is contained by the right operand of the Constraint."@en ;
+	rdfs:label "Is part of"@en .
+
+:lt
+	a :Operator, owl:NamedIndividual, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	skos:definition "Indicating that a given value is less than the right operand of the Constraint."@en ;
+	rdfs:label "Less than"@en .
+
+:lteq
+	a :Operator, owl:NamedIndividual, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	skos:definition "Indicating that a given value is less than or equal to the right operand of the Constraint."@en ;
+	rdfs:label "Less than or equal to"@en .
+
+:neq
+	a :Operator, owl:NamedIndividual, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	skos:definition "Indicating that a given value is not equal to the right operand of the Constraint."@en ;
+	rdfs:label "Not equal to"@en .
+
+:andSequence
+	a rdf:Property , owl:ObjectProperty, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+    rdfs:subPropertyOf :operand ;
+	rdfs:label "And Sequence"@en ;
+	skos:definition "The relation is satisfied when each of the Constraints are satisfied in the order specified."@en ;
+	skos:note "This property MUST only be used for Logical Constraints, and the list of operand values MUST be Constraint instances. The order of the list MUST be preserved. The andSequence operator is an example where there may be temporal conditional requirements between the operands. This may lead to situations where the outcome is unresolvable, such as deadlock if one of the Constraints is unable to be satisfied. ODRL Processing systems SHOULD plan for these scenarios and implement mechanisms to resolve them."@en .
+
+:or
+	a rdf:Property , owl:ObjectProperty, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+    rdfs:subPropertyOf :operand ;
+	skos:definition "The relation is satisfied when at least one of the Constraints is satisfied."@en ;
+	rdfs:label "Or"@en ;
+	skos:note "This property MUST only be used for Logical Constraints, and the list of operand values MUST be Constraint instances."@en .
+	
+:and
+	a rdf:Property , owl:ObjectProperty, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+    rdfs:subPropertyOf :operand ;
+	skos:definition "The relation is satisfied when all of the Constraints are satisfied."@en ;
+	skos:note "This property MUST only be used for Logical Constraints, and the list of operand values MUST be Constraint instances."@en ;
+	rdfs:label "And"@en .
+
+:xone
+	a rdf:Property , owl:ObjectProperty, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+    rdfs:subPropertyOf :operand ;
+	skos:definition "The relation is satisfied when only one, and not more, of the Constaints is satisfied"@en ;
+	rdfs:label "Only One"@en ;
+	skos:note "This property MUST only be used for Logical Constraints, and the list of operand values MUST be Constraint instances."@en .
+	
+
+
+## LeftOperand
+
+:LeftOperand
+	a rdfs:Class , owl:Class, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:label "Left Operand"@en ;
+	skos:definition "Left operand for constraint expression."@en ;
+	skos:note "Instances of the LeftOperand class are used as the leftOperand of a Constraint."@en .
+
+## Left Operands
+
+:absolutePosition
+	a :LeftOperand, owl:NamedIndividual, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:label "Absolute Asset Position"@en ;
+	skos:definition "A point in space or time defined with absolute coordinates for the positioning of the Asset."@en ;
+	skos:note "Example: The upper left corner of a picture may be constrained to a specific position of the canvas rendering it."@en ;
+    skos:scopeNote "Non-Normative"@en .
+
+:absoluteSpatialPosition
+	a :LeftOperand, owl:NamedIndividual, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	skos:broaderTransitive :absolutePosition;
+	rdfs:label "Absolute Spatial Asset Position"@en ;
+	skos:definition "The absolute spatial positions of four corners of a rectangle on a 2D-canvas or the eight corners of a cuboid in a 3D-space for the Asset to fit."@en ;
+	skos:note "Example: The upper left corner of a picture may be constrained to a specific position of the canvas rendering it. Note: see also the Left Operand Relative Spatial Asset Position. "@en ;
+   skos:scopeNote "Non-Normative"@en .
+
+:absoluteTemporalPosition
+	a :LeftOperand, owl:NamedIndividual, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	skos:broaderTransitive :absolutePosition;
+	rdfs:label "Absolute Temporal Asset Position"@en ;
+	skos:definition "The absolute temporal positions in a media stream the Asset has to fit."@en ;
+	skos:note "Note: Use with Actions including the Asset in a larger media stream. The fragment part of a Media Fragment URI (https://www.w3.org/TR/media-frags/) may be used for the right operand. See the Left Operand realativeTemporalPosition. Example: The MP3 music file must be positioned between second 192 and 250 of the temporal length of a stream."@en ;
+   skos:scopeNote "Non-Normative"@en .
+
+:absoluteSize
+	a :LeftOperand, owl:NamedIndividual, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:label "Absolute Asset Size"@en ;
+	skos:definition "Measure(s) of one or two axes for 2D-objects or measure(s) of one to tree axes for 3D-objects of the Asset."@en ;
+	skos:note "Example: The image can be resized in width to a maximum of 1000px."@en ;
+    skos:scopeNote "Non-Normative"@en .
+
+:count
+	a :LeftOperand, owl:NamedIndividual, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:label "Count"@en ;
+	skos:definition "Numeric count."@en ;
+    skos:scopeNote "Non-Normative"@en .
+
+:dateTime
+	a :LeftOperand, owl:NamedIndividual, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:label "Datetime"@en ;
+	skos:definition "The date (and optional time and timezone) to be compared. Right operand value MUST be an xsd:date or xsd:dateTime as defined by [[xmlschema11-2]]."@en ;
+	skos:note "The use of Timezone information is strongly recommended."@en ;
+	skos:note "The Rule may be exercised before (with operator lt/lteq) or after (with operator gt/gteq) the date(time) defined by the Right operand. Example: <code>dateTime gteq 2017-12-31T06:00Z</code> means the Rule can only be exercised after (and including) 6:00AM on the 31st Decemeber 2017 UTC time."@en ;
+    skos:scopeNote "Non-Normative"@en .
+
+:delayPeriod
+	a :LeftOperand, owl:NamedIndividual, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:label "Delay Period"@en ;
+	skos:definition "A time delay period. The point in time triggering this period MAY be defined by another temporal Constraint expressed together in a Constraint (utilising the odrl:andSequence operator). Right operand value MUST be an xsd:duration as defined by [[xmlschema11-2]]."@en ;
+	skos:note "Only the eq, gt, gteq operators SHOULD be used."@en ;
+	skos:note "Example: <code>delayPeriod eq P60M</code> indicates a delay of 60 Minutes before exercising the action."@en ;
+    skos:scopeNote "Non-Normative"@en .
+
+:deliveryChannel
+	a :LeftOperand, owl:NamedIndividual, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:label "Delivery Channel"@en ;
+	skos:definition "The delivery channel used."@en ;
+	skos:note "Example: the asset may be distributed only on mobile networks."@en ;
+    skos:scopeNote "Non-Normative"@en .
+
+:device
+	a :LeftOperand, owl:NamedIndividual, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:label "Device"@en ;
+	skos:definition "An identified computing system."@en ;
+    owl:deprecated true ;
+	skos:exactMatch :systemDevice .
+
+:elapsedTime
+	a :LeftOperand, owl:NamedIndividual, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:label "Elapsed Time"@en ;
+	skos:definition "An elapsed time period. Right operand value MUST be an xsd:duration as defined by [[xmlschema11-2]]."@en ;
+	skos:note "Only the eq, lt, lteq operators SHOULD be used."@en ;
+	skos:note "Example: <code>elpasedTime eq P60M</code> indicates a total elapsed time of 60 Minutes." ;
+    skos:scopeNote "Non-Normative"@en .
+
+:event
+	a :LeftOperand, owl:NamedIndividual, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:label "Event"@en ;
+	skos:definition "An identified event."@en ;
+	skos:note "Events are temporal periods of time, and operators can be used to signal before (lt), during (eq) or after (gt) the event. Example: May be taken during the “FIFA World Cup 2020” only."@en ;
+    skos:scopeNote "Non-Normative"@en .
+
+:fileFormat
+	a :LeftOperand, owl:NamedIndividual, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:label "File Format"@en ;
+	skos:definition "A transformed file format."@en ;
+	skos:note "Example: An asset may be transformed into JPEG format."@en ;
+    skos:scopeNote "Non-Normative"@en .
+
+:industry
+	a :LeftOperand, owl:NamedIndividual, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:label "Industry Context"@en ;
+	skos:definition "A defined industry sector."@en ;
+	skos:note "Example: publishing or financial industry."@en ;
+    skos:scopeNote "Non-Normative"@en .
+
+:language
+	a :LeftOperand, owl:NamedIndividual, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:label "Language"@en ;
+	skos:definition "A natural language."@en ;
+	skos:note "Example: the asset can only be translated into Greek. Must use [[bcp47]] codes for language values."@en ;
+    skos:scopeNote "Non-Normative"@en .
+  
+:media
+	a :LeftOperand, owl:NamedIndividual, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:label "Media Context"@en ;
+	skos:definition "Category of media context."@en ;
+	skos:note "Example media types: electronic, print, advertising, marketing. Note: The used type should not be an IANA MediaType as they are focused on technical characteristics. "@en ;
+    skos:scopeNote "Non-Normative"@en .
+
+:meteredTime
+	a :LeftOperand, owl:NamedIndividual, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:label "Metered Time"@en ;
+	skos:definition "An accumulated amount of time period. Right operand value MUST be an xsd:duration as defined by [[xmlschema11-2]]."@en ;
+	skos:note "Only the eq, lt, lteq operators SHOULD be used."@en ;
+	skos:note "Example: <code>meteredTime lteq P60M</code> indicates an accumulated period of 60 Minutes or less." ;
+    skos:scopeNote "Non-Normative"@en .
+
+:payAmount
+	a :LeftOperand, owl:NamedIndividual, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:label "Payment Amount"@en ;
+	skos:definition "The amount of a financial payment. Right operand value MUST be an xsd:decimal. "@en ;
+	skos:note "Note: Can be used for compensation duties with the unit property indicating the currency of the payment."@en ;
+    skos:scopeNote "Non-Normative"@en .
+
+:percentage
+	a :LeftOperand, owl:NamedIndividual, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:label "Asset Percentage"@en ;
+	skos:definition "A percentage amount. Right operand value MUST be an xsd:decimal from 0 to 100."@en ;
+	skos:note "Example: Extract less than or equal to 50%."@en ;
+    skos:scopeNote "Non-Normative"@en .
+
+:product
+	a :LeftOperand, owl:NamedIndividual, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:label "Product Context"@en ;
+	skos:definition "A Product or service."@en ;
+	skos:note "Example: May only be used in the XYZ Magazine."@en ;
+    skos:scopeNote "Non-Normative"@en .
+
+:purpose
+	a :LeftOperand, owl:NamedIndividual, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:label "Purpose"@en ;
+	skos:definition "A defined Purpose."@en ;
+	skos:note "Example: Educational use."@en ;
+    skos:scopeNote "Non-Normative"@en .
+
+:recipient
+	a :LeftOperand, owl:NamedIndividual, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:label "Recipient"@en ;
+	skos:definition "The party receiving the result/outcome."@en ;
+	skos:note "Note: The Right Operand must identify one or more specific Parties or category/ies of the Party."@en ;
+    skos:scopeNote "Non-Normative"@en .
+
+:relativePosition
+	a :LeftOperand, owl:NamedIndividual, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:label "Relative Asset Position"@en ;
+	skos:definition "A point in space or time defined with coordinates relative to full measures the positioning of the Asset."@en ;
+	skos:note "Example: The upper left corner of a picture may be constrained to a specific position of the canvas rendering it."@en ;
+  skos:scopeNote "Non-Normative"@en .
+
+:relativeSpatialPosition
+	a :LeftOperand, owl:NamedIndividual, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	skos:broaderTransitive :relativePosition;
+	rdfs:label "Relative Spatial Asset Position"@en ;
+	skos:definition "The relative spatial positions - expressed as percentages of full values - of four corners of a rectangle on a 2D-canvas or the eight corners of a cuboid in a 3D-space of the Asset."@en ;
+	skos:note "Note: See the Left Operand absoluteSpatialAssetPosition."@en ;
+  skos:scopeNote "Non-Normative"@en .
+
+:relativeTemporalPosition
+	a :LeftOperand, owl:NamedIndividual, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	skos:broaderTransitive :relativePosition;
+	rdfs:label "Relative Temporal Asset Position"@en ;
+	skos:definition "A point in space or time defined with coordinates relative to full measures the positioning of the Asset."@en ;
+	skos:note "Example: The MP3 music file must be positioned between the positions at 33% and 48% of the temporal length of a stream. Note: See the Left Operand absoluteTemporalAssetPosition. "@en ;
+  skos:scopeNote "Non-Normative"@en .
+
+:relativeSize
+	a :LeftOperand, owl:NamedIndividual, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:label "Relative Asset Size"@en ;
+	skos:definition "Measure(s) of one or two axes for 2D-objects or measure(s) of one to tree axes for 3D-objects - expressed as percentages of full values - of the Asset."@en ;
+	skos:note "Example: The image can be resized in width to a maximum of 200%. Note: See the Left Operand absoluteSize. "@en ;
+  skos:scopeNote "Non-Normative"@en .
+
+:resolution
+	a :LeftOperand, owl:NamedIndividual, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:label "Rendition Resolution"@en ;
+	skos:definition "Resolution of the rendition of the Asset."@en ;
+	skos:note "Example: the image may be printed at 1200dpi."@en ;
+    skos:scopeNote "Non-Normative"@en .
+
+:spatial
+	a :LeftOperand, owl:NamedIndividual, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:label "Geospatial Named Area"@en ;
+	skos:definition "A named and identified geospatial area with defined borders. An IRI MUST be used to represent this value."@en ;
+	skos:note "A code value for the area and source of the code must be presented in the Right Operand. For example, the [[iso3166]] Country Codes or the Getty Thesaurus of Geographic Names. "@en ;
+    skos:scopeNote "Non-Normative"@en .
+
+:spatialCoordinates
+	a :LeftOperand, owl:NamedIndividual, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	skos:broaderTransitive :spatial;
+	rdfs:label "Geospatial Coordinates"@en ;
+	skos:definition "A set of coordinates setting the borders of a geospatial area. The coordinates MUST include longitude and latitude, they MAY include altitude and the geodetic datum."@en ;
+	skos:note "The default values are the altitude of earth's surface at this location and the WGS 84 datum."@en ;
+    skos:scopeNote "Non-Normative"@en .
+
+:system
+	a :LeftOperand, owl:NamedIndividual, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:label "System"@en ;
+	skos:definition "An identified computing system."@en ;
+    owl:deprecated true ;
+	skos:exactMatch :systemDevice .
+
+:systemDevice
+	a :LeftOperand, owl:NamedIndividual, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	skos:exactMatch :system, :device ;
+	rdfs:label "System Device"@en ;
+	skos:definition "An identified computing system."@en ;
+	skos:note "Example: The system device can be identified by a unique code created from the used hardware."@en ;
+    skos:scopeNote "Non-Normative"@en .
+
+:timeInterval
+	a :LeftOperand, owl:NamedIndividual, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:label "Recurring Time Interval"@en ;
+	skos:definition "A recurring period of time. Right operand value MUST be an xsd:duration as defined by [[xmlschema11-2]]."@en ;
+	skos:note "Only the eq operator SHOULD be used."@en ;
+	skos:note "Example: <code>timeInterval eq P7D</code> indicates a recurring 7 day period." ;
+    skos:scopeNote "Non-Normative"@en .
+
+:unitOfCount
+	a :LeftOperand, owl:NamedIndividual, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:label "Unit Of Count"@en ;
+	skos:definition "The unit of measure used for counting."@en ;
+	skos:note "Typically used with Duties to indicate the unit entity to be counted of the Action. Example: A duty to compensate and a unitOfCount constraint of 'perUser' would indicate that the compensation by multiplied by the 'number of users'."@en ;
+    skos:scopeNote "Non-Normative"@en .
+
+:version
+	a :LeftOperand, owl:NamedIndividual, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:label "Version"@en ;
+	skos:definition "The range of versions of the Asset."@en ;
+	skos:note "Example: Single Paperback or Multiple Issues or version 2.0 or higher."@en ;
+    skos:scopeNote "Non-Normative"@en .
+
+:virtualLocation
+	a :LeftOperand, owl:NamedIndividual, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:label "Virtual IT Communication Location"@en ;
+	skos:definition "An identified location of the IT communication space."@en ;
+	skos:note "Example: an Internet domain or IP address range."@en ;
+  skos:scopeNote "Non-Normative"@en .
+
+
+## RightOperand
+
+:RightOperand
+	a rdfs:Class , owl:Class, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:label "Right Operand"@en ;
+	skos:definition "Right operand for constraint expression."@en ;
+	skos:note "Instances of the RightOperand class are used as the rightOperand of a Constraint."@en .
+
+:policyUsage
+	a :RightOperand, owl:NamedIndividual, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:label "Policy Usage Time"@en ;
+	skos:definition "Indicates the time when the policy is exercised."@en ;
+	skos:note "This can be used to express constraints related to the time the policy is exercised. For example,  <code>event lt policyUsage</code> expresses a constraint on the Action to occur before the policy is exercised. Other operators may be used to indicate during (eg) or after (gt, gte) policy usage."@en ;
+    skos:scopeNote "Non-Normative"@en .
+
+## Actions
+
+:use
+	a :Action, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:label "Use"@en ;
+	skos:definition "To use the Asset"@en ;
+	skos:note "Use is the most generic action for all non-third-party usage. More specific types of the use action can be expressed by more targetted actions."@en .
+
+:grantUse
+	a :Action, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:label "Grant Use"@en ;
+	skos:definition "To grant the use of the Asset to third parties."@en ;
+	skos:note "This action enables the assignee to create policies for the use of the Asset for third parties. The nextPolicy is recommended to be agreed with the third party. Use of temporal constraints is recommended."@en ;
+	:includedIn odrl:use ;
+    skos:scopeNote "Non-Normative"@en .
+
+:compensate
+	a :Action, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:label "Compensate"@en ;
+	skos:definition "To compensate by transfer of some amount of value, if defined, for using or selling the Asset."@en ;
+	skos:note "The compensation may use different types of things with a value: (i) the thing is expressed by the value (term) of the Constraint name; (b) the value is expressed by operator, rightOperand, dataType and unit. Typically the assignee will compensate the assigner, but other compensation party roles may be used."@en ;
+	:includedIn odrl:use ;
+    skos:scopeNote "Non-Normative"@en .
+
+:acceptTracking
+	a :Action, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	:includedIn odrl:use ;
+	rdfs:label "Accept Tracking"@en ;
+	skos:definition "To accept that the use of the Asset may be tracked."@en ;
+	skos:note "The collected information may be tracked by the Assigner, or may link to a Party with the role 'trackingParty' function."@en ;
+    skos:scopeNote "Non-Normative"@en .
+
+
+:aggregate
+	a :Action, skos:Concept ;
+	:includedIn odrl:use ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:label "Aggregate"@en ;
+	skos:definition "To use the Asset or parts of it as part of a composite collection."@en ;
+	:includedIn odrl:use ;
+    skos:scopeNote "Non-Normative"@en .
+
+:annotate
+	a :Action, skos:Concept ;
+	:includedIn odrl:use ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:label "Annotate"@en ;
+	skos:definition "To add explanatory notations/commentaries to the Asset without modifying the Asset in any other way."@en ;
+    skos:scopeNote "Non-Normative"@en .
+
+:anonymize
+	a :Action, skos:Concept ;
+	:includedIn odrl:use ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:label "Anonymize"@en ;
+	skos:definition "To anonymize all or parts of the Asset."@en ;
+	skos:note "For example, to remove identifying particulars for statistical or for other comparable purposes, or to use the Asset without stating the author/source."@en ;
+    skos:scopeNote "Non-Normative"@en .
+
+:append
+	a :Action, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:label "Append"@en ;
+	skos:definition "The act of adding to the end of an asset."@en ;
+    owl:deprecated true ;
+	skos:exactMatch :modify .
+
+:appendTo
+	a :Action, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:label "Append To"@en ;
+#	skos:broaderTransitive odrl:writeTo ;
+	skos:definition "The act of appending data to the Asset without modifying the Asset in any other way."@en ;
+    owl:deprecated true ;
+	skos:exactMatch :modify .
+
+:archive
+	a :Action, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	:includedIn odrl:use ;
+	rdfs:label "Archive"@en ;
+	skos:definition "To store the Asset (in a non-transient form)."@en ;
+	skos:note "Temporal constraints may be used for temporal conditions."@en ;
+    skos:scopeNote "Non-Normative"@en .
+
+:attribute
+	a :Action, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	:includedIn odrl:use ;
+	rdfs:label "Attribute"@en ;
+	skos:definition "To attribute the use of the Asset."@en ;
+	skos:note "May link to an Asset with the attribution information. May link to a Party with the  role “attributedParty” function."@en ;
+    skos:scopeNote "Non-Normative"@en .
+
+:concurrentUse
+	a :Action, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:label "Concurrent Use"@en ;
+	skos:definition "To create multiple copies of the Asset that are being concurrently used."@en ;
+	:includedIn odrl:use ;
+    skos:scopeNote "Non-Normative"@en .
+
+:copy
+	a :Action, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	owl:sameAs :reproduce ;
+	rdfs:label "Copy"@en ;
+	skos:definition "The act of making an exact reproduction of the asset."@en ;
+    owl:deprecated true ;
+	skos:exactMatch :reproduce .
+
+:delete
+	a :Action, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	:includedIn odrl:use ;
+	rdfs:label "Delete"@en ;
+	skos:definition "To permanently remove all copies of the Asset after it has been used."@en ;
+	skos:note "Use a constraint to define under which conditions the Asset must be deleted."@en ;
+    skos:scopeNote "Non-Normative"@en .
+
+:derive
+	a :Action, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:label "Derive"@en ;
+	skos:definition "To create a new derivative Asset from this Asset and to edit or modify the derivative."@en ;
+	skos:note "A new asset is created and may have significant overlaps with the original Asset. (Note that the notion of whether or not the change is significant enough to qualify as a new asset is subjective). To the derived Asset a next policy may be applied."@en ;
+	:includedIn odrl:use ;
+    skos:scopeNote "Non-Normative"@en .
+
+:digitize
+	a :Action, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:label "Digitize"@en ;
+	:includedIn odrl:use ;
+	skos:definition "To produce a digital copy of (or otherwise digitize) the Asset from its analogue form."@en ;
+    skos:scopeNote "Non-Normative"@en .
+
+:display
+	a :Action, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:label "Display"@en ;
+	skos:definition "To create a static and transient rendition of an Asset."@en ;
+	skos:note "For example, displaying an image on a screen. If the action is to be performed to a wider audience than just the Assignees, then the Recipient constraint is recommended to be used."@en ;
+	:includedIn odrl:play ;
+    skos:scopeNote "Non-Normative"@en .
+
+:distribute
+	a :Action, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:label "Distribute"@en ;
+	skos:definition "To supply the Asset to third-parties."@en ;
+	skos:note "It is recommended to use nextPolicy to express the allowable usages by third-parties."@en ;
+	:includedIn odrl:use ;
+    skos:scopeNote "Non-Normative"@en .
+
+:ensureExclusivity
+	a :Action, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	:includedIn odrl:use ;
+	rdfs:label "Ensure Exclusivity"@en ;
+	skos:definition "To ensure that the Rule on the Asset is exclusive."@en ;
+	skos:note "If used as a Duty, the assignee should be explicitly indicated as the party that is ensuring the exclusivity of the Rule."@en ;
+    skos:scopeNote "Non-Normative"@en .
+
+:execute
+	a :Action, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:label "Execute"@en ;
+	skos:definition "To run the computer program Asset."@en ;
+	skos:note "For example, machine executable code or Java such as a game or application."@en ;
+    :includedIn odrl:use ;
+    skos:scopeNote "Non-Normative"@en .
+
+:export
+	a :Action, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:label "Export"@en ;
+	skos:definition "The act of transforming the asset into a new form."@en ;
+    owl:deprecated true ;
+	skos:exactMatch :transform .
+
+
+:extract
+	a :Action, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:label "Extract"@en ;
+	skos:definition "To extract parts of the Asset and to use it as a new Asset."@en ;
+	skos:note "A new asset is created and may have very little in common with the original Asset. (Note that the notion of whether or not the change is significant enough to qualify as a new asset is subjective). To the extracted Asset a next policy may be applied."@en ;
+	:includedIn odrl:reproduce ;
+    skos:scopeNote "Non-Normative"@en .
+
+:give
+	a :Action, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:label "Give"@en ;
+	skos:definition "To transfer the ownership of the Asset to a third party without compensation and while deleting the original asset."@en ;
+	:includedIn :transfer ;
+    skos:scopeNote "Non-Normative"@en .
+
+:include
+	a :Action, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:label "Include"@en ;
+	:includedIn odrl:use ;
+	skos:definition "To include other related assets in the Asset."@en ;
+	skos:note "For example: bio picture must be included in the attribution. Use of a relation sub-property is required for the related assets."@en ;
+    skos:scopeNote "Non-Normative"@en .
+
+:index
+	a :Action, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:label "Index"@en ;
+	skos:definition "To record the Asset in an index."@en ;
+	skos:note "For example, to include a link to the Asset in a search engine database."@en ;
+    :includedIn odrl:use ;
+    skos:scopeNote "Non-Normative"@en .
+
+:inform
+	a :Action, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	:includedIn odrl:use ;
+	rdfs:label "Inform"@en ;
+	skos:definition "To inform that an action has been performed on or in relation to the Asset."@en ;
+	skos:note "May link to a Party with the role 'informedParty' function."@en ;
+    skos:scopeNote "Non-Normative"@en .
+
+:install
+	a :Action, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:label "Install"@en ;
+	skos:definition "To load the computer program Asset onto a storage device which allows operating or running the Asset."@en ;
+	:includedIn odrl:use ;
+    skos:scopeNote "Non-Normative"@en .
+
+:lease
+	a :Action, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:label "Lease"@en ;
+	skos:definition "The act of making available the asset to a third-party for a fixed period of time with exchange of value."@en ;
+    owl:deprecated true .
+
+
+:license
+	a :Action, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:label "License"@en ;
+	skos:definition "The act of granting the right to use the asset to a third-party."@en ;
+    owl:deprecated true ;
+	skos:exactMatch :grantUse .
+
+
+:lend
+	a :Action, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:label "Lend"@en ;
+	skos:definition "The act of making available the asset to a third-party for a fixed period of time without exchange of value."@en ;
+    owl:deprecated true .
+
+
+:modify
+	a :Action, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:label "Modify"@en ;
+	skos:definition "To change existing content of the Asset. A new asset is not created by this action."@en ;
+	skos:note "This action will modify an asset which is typically updated from time to time without creating a new asset. If the result from modifying the asset should be a new asset the actions derive or extract should be used. (Note that the notion of whether or not the change is significant enough to qualify as a new asset is subjective)."@en ;
+	:includedIn odrl:use ;
+    skos:scopeNote "Non-Normative"@en .
+
+:move
+	a :Action, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:label "Move"@en ;
+	skos:definition "To move the Asset from one digital location to another including deleting the original copy."@en ;
+	skos:note "After the Asset has been moved, the original copy must be deleted."@en ;
+	:includedIn odrl:use ;
+    skos:scopeNote "Non-Normative"@en .
+
+:nextPolicy
+	a :Action, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	:includedIn odrl:use ;
+	rdfs:label "Next Policy"@en ;
+	skos:definition "To grant the specified Policy to a third party for their use of the Asset."@en ;
+	skos:note "Useful for downstream policies."@en ;
+    skos:scopeNote "Non-Normative"@en .
+
+:obtainConsent
+	a :Action, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	:includedIn odrl:use ;
+	rdfs:label "Obtain Consent"@en ;
+	skos:definition "To obtain verifiable consent to perform the requested action in relation to the Asset."@en ;
+	skos:note "May be used as a Duty to ensure that the Assigner or a Party is authorized to approve such actions on a case-by-case basis. May link to a Party with the role “consentingParty” function."@en ;
+    skos:scopeNote "Non-Normative"@en .
+
+:pay
+	a :Action, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:label "Pay"@en ;
+	skos:definition "The act of paying a financial amount to a party for use of the asset."@en ;
+    owl:deprecated true ;
+	skos:exactMatch :compensate .
+
+:play
+	a :Action, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:label "Play"@en ;
+	:includedIn odrl:use ;
+	skos:definition "To create a sequential and transient rendition of an Asset."@en ;
+    skos:note "For example, to play a video or audio track. If the action is to be performed to a wider audience than just the Assignees, then the Recipient constraint is recommended to be used.";
+    skos:scopeNote "Non-Normative"@en .
+
+:present
+	a :Action, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:label "Present"@en ;
+	skos:definition "To publicly perform the Asset."@en ;
+    :includedIn odrl:use ;
+    skos:note "The asset can be performed (or communicated) in public.";
+    skos:scopeNote "Non-Normative"@en .
+
+:preview
+	a :Action, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:label "Preview"@en ;
+	skos:definition "The act of providing a short preview of the asset."@en ;
+    skos:note "Use a time constraint with the appropriate action."@en ;
+    owl:deprecated true .
+
+
+:print
+	a :Action, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:label "Print"@en ;
+	skos:definition "To create a tangible and permanent rendition of an Asset."@en ;
+	skos:note "For example, creating a permanent, fixed (static), and directly perceivable representation of the Asset, such as printing onto paper."@en ;
+	:includedIn odrl:use ;
+    skos:scopeNote "Non-Normative"@en .
+
+:read
+	a :Action, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:label "Read"@en ;
+	skos:definition "To obtain data from the Asset."@en ;
+	skos:note "For example, the ability to read a record from a database (the Asset)."@en ;
+	:includedIn odrl:use ;
+    skos:scopeNote "Non-Normative"@en .
+
+:reproduce
+	a :Action, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:label "Reproduce"@en ;
+	skos:definition "To make duplicate copies the Asset in any material form."@en ;
+	:includedIn odrl:use ;
+    skos:scopeNote "Non-Normative"@en .
+
+:reviewPolicy
+	a :Action, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	:includedIn odrl:use ;
+	rdfs:label "Review Policy"@en ;
+	skos:definition "To review the Policy applicable to the Asset."@en ;
+	skos:note "Used when human intervention is required to review the Policy. May link to an Asset which represents the full Policy information."@en ;
+    skos:scopeNote "Non-Normative"@en .
+
+:secondaryUse
+	a :Action, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:label "Secondary Use"@en ;
+	skos:definition "The act of using the asset for a purpose other than the purpose it was intended for."@en ;
+    owl:deprecated true .
+
+:sell
+	a :Action, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:label "Sell"@en ;
+	skos:definition "To transfer the ownership of the Asset to a third party with compensation and while deleting the original asset."@en ;
+	:includedIn :transfer ;
+    skos:scopeNote "Non-Normative"@en .
+
+:stream
+	a :Action, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:label "Stream"@en ;
+	skos:definition "To deliver the Asset in real-time."@en ;
+	:includedIn odrl:use ;
+    skos:note "The Asset maybe utilised in real-time as it is being delivered. If the action is to be performed to a wider audience than just the Assignees, then the Recipient constraint is recommended to be used.";
+    skos:scopeNote "Non-Normative"@en .
+
+:synchronize
+	a :Action, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:label "Synchronize"@en ;
+	skos:definition "To use the Asset in timed relations with media (audio/visual) elements of another Asset."@en ;
+	:includedIn odrl:use ;
+    skos:scopeNote "Non-Normative"@en .
+
+:textToSpeech
+	a :Action, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:label "Text-to-speech"@en ;
+	skos:definition "To have a text Asset read out loud."@en ;
+    :includedIn odrl:use ;
+    skos:note "If the action is to be performed to a wider audience than just the Assignees, then the recipient constraint is recommended to be used.";
+    skos:scopeNote "Non-Normative"@en .
+
+:transfer
+	a :Action, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:label "Transfer Ownership"@en ;
+	skos:definition "To transfer the ownership of the Asset in perpetuity."@en .
+
+:transform
+	a :Action, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:label "Transform"@en ;
+	skos:definition "To convert the Asset into a different format."@en ;
+	skos:note "Typically used to convert the Asset into a different format for consumption on/transfer to a third party system."@en ;
+	:includedIn odrl:use ;
+    skos:scopeNote "Non-Normative"@en .
+
+:translate
+	a :Action, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:label "Translate"@en ;
+	skos:definition "To translate the original natural language of an Asset into another natural language."@en ;
+	skos:note "A new derivative Asset is created by that action."@en ;
+	:includedIn odrl:use ;
+    skos:scopeNote "Non-Normative"@en .
+
+:uninstall
+	a :Action, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:label "Uninstall"@en ;
+	:includedIn odrl:use ;
+	skos:definition "To unload and delete the computer program Asset from a storage device and disable its readiness for operation."@en ;
+	skos:note "The Asset is no longer accessible to the assignees after it has been used."@en ;
+    skos:scopeNote "Non-Normative"@en .
+
+:watermark
+	a :Action, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	:includedIn odrl:use ;
+	rdfs:label "Watermark"@en ;
+	skos:definition "To apply a watermark to the Asset."@en ;
+    skos:scopeNote "Non-Normative"@en .
+
+:write
+	a :Action, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:label "Write"@en ;
+	skos:definition "The act of writing to the Asset."@en ;
+    owl:deprecated true ;
+	skos:exactMatch :modify .
+
+
+:writeTo
+	a :Action, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:label "Write to"@en ;
+	skos:definition "The act of adding data to the Asset."@en ;
+    owl:deprecated true ;
+	skos:exactMatch :modify .
+
+
+## Functions
+
+:assignee
+	a rdf:Property , owl:ObjectProperty, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:subPropertyOf :function ;
+	rdfs:label "Assignee"@en ;
+	skos:definition "The Party is the recipient of the Rule."@en ;
+	rdfs:domain [
+		a owl:Class ;
+		owl:unionOf ( :Rule :Policy ) ;
+	] ;
+	rdfs:range :Party .
+
+:assigner
+	a rdf:Property , owl:ObjectProperty, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:subPropertyOf :function ;
+	rdfs:label "Assigner"@en ;
+	skos:definition "The Party is the issuer of the Rule."@en ;
+	rdfs:domain [
+		a owl:Class ;
+		owl:unionOf ( :Rule :Policy ) ;
+	] ;
+	rdfs:range :Party .
+
+:assigneeOf
+	a rdf:Property , owl:ObjectProperty, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:label "Assignee Of"@en ;
+	skos:definition "Identifies an ODRL Policy for which the identified Party undertakes the assignee functional role."@en ;
+	skos:note "When assigneeOf has been asserted between a metadata expression and an ODRL Policy, the Party being identified MUST be inferred to undertake the assignee functional role of all the Rules of that Policy."@en ;
+    rdfs:domain :Party ;
+	rdfs:range :Policy .
+
+:assignerOf
+	a rdf:Property , owl:ObjectProperty, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:label "Assigner Of"@en ;
+	skos:definition "Identifies an ODRL Policy for which the identified Party undertakes the assigner functional role."@en ;
+	skos:note "When assignerOf has been asserted between a metadata expression and an ODRL Policy, the Party being identified MUST be inferred to undertake the assigner functional role of all the Rules of that Policy."@en ;
+    rdfs:domain :Party ;
+	rdfs:range :Policy .
+
+:attributedParty
+	a rdf:Property , owl:ObjectProperty, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:subPropertyOf :function ;
+	rdfs:label "Attributed Party"@en ;
+	skos:definition "The Party to be attributed."@en ;
+	skos:note "Maybe specified as part of the attribute action."@en ;
+    skos:scopeNote "Non-Normative"@en .
+
+:attributingParty
+	a rdf:Property , owl:ObjectProperty, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:subPropertyOf :function ;
+	rdfs:label "Attributing Party"@en ;
+	skos:definition "The Party who undertakes the attribution."@en ;
+	skos:note "Maybe specified as part of the attribute action."@en ;
+    skos:scopeNote "Non-Normative"@en .
+
+:consentingParty
+	a rdf:Property , owl:ObjectProperty, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:subPropertyOf :function ;
+	rdfs:label "Consenting Party"@en ;
+	skos:definition "The Party to obtain consent from."@en ;
+	skos:note "Maybe specified as part of the obtainConsent action."@en ;
+    skos:scopeNote "Non-Normative"@en .
+
+:consentedParty
+	a rdf:Property , owl:ObjectProperty, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:subPropertyOf :function ;
+	rdfs:label "Consented Party"@en ;
+	skos:definition "The Party who obtains the consent."@en ;
+	skos:note "Maybe specified as part of the obtainConsent action."@en ;
+    skos:scopeNote "Non-Normative"@en .
+
+:informedParty
+	a rdf:Property , owl:ObjectProperty, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:subPropertyOf :function ;
+	rdfs:label "Informed Party"@en ;
+	skos:definition "The Party to be informed of all uses."@en ;
+	skos:note "Maybe specified as part of the inform action."@en ;
+    skos:scopeNote "Non-Normative"@en .
+
+:informingParty
+	a rdf:Property , owl:ObjectProperty, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:subPropertyOf :function ;
+	rdfs:label "Informing Party"@en ;
+	skos:definition "The Party who provides the inform use data."@en ;
+	skos:note "Maybe specified as part of the inform action."@en ;
+    skos:scopeNote "Non-Normative"@en .
+
+:payeeParty
+	a rdf:Property , owl:ObjectProperty, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:label "Payee Party"@en ;
+	skos:definition "The Party is the recipient of the payment."@en ;
+    owl:deprecated true ;
+	skos:exactMatch :compensatedParty ;
+    skos:scopeNote "Non-Normative"@en .
+
+
+:compensatedParty
+	a rdf:Property , owl:ObjectProperty, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:subPropertyOf :function ;
+	rdfs:label "Compensated Party"@en ;
+	skos:definition "The Party is the recipient of the compensation."@en ;
+	skos:note "Maybe specified as part of the compensate duty action."@en ;
+    skos:scopeNote "Non-Normative"@en .
+
+:compensatingParty
+	a rdf:Property , owl:ObjectProperty, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:subPropertyOf :function ;
+	rdfs:label "Compensating Party"@en ;
+	skos:definition "The Party that is the provider of the compensation."@en ;
+	skos:note "Maybe specified as part of the compensate duty action."@en ;
+    skos:scopeNote "Non-Normative"@en .
+
+:trackingParty
+	a rdf:Property , owl:ObjectProperty, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:subPropertyOf :function ;
+	rdfs:label "Tracking Party"@en ;
+	skos:definition "The Party who is tracking usage."@en ;
+	skos:note "May be specified as part of the acceptTracking action."@en ;
+    skos:scopeNote "Non-Normative"@en .
+
+:trackedParty
+	a rdf:Property , owl:ObjectProperty, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:subPropertyOf :function ;
+	rdfs:label "Tracked Party"@en ;
+	skos:definition "The Party whose usage is being tracked."@en ;
+	skos:note "May be specified as part of the acceptTracking action."@en ;
+    skos:scopeNote "Non-Normative"@en .
+
+:contractingParty
+	a rdf:Property , owl:ObjectProperty, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:subPropertyOf :function ;
+	rdfs:label "Contracting Party"@en ;
+	skos:definition "The Party who is offering the contract."@en ;
+    skos:scopeNote "Non-Normative"@en .
+
+:contractedParty
+	a rdf:Property , owl:ObjectProperty, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:subPropertyOf :function ;
+	rdfs:label "Contracted Party"@en ;
+	skos:definition "The Party who is being contracted."@en ;
+    skos:scopeNote "Non-Normative"@en .
+
+## Policies
+
+:Agreement
+	a rdfs:Class , owl:Class, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:subClassOf :Policy ;
+	owl:disjointWith :Offer, :Privacy, :Request, :Set, :Ticket, :Assertion ;
+	rdfs:label "Agreement"@en ;
+	skos:definition "A Policy that grants the assignee a Rule over an Asset from an assigner."@en ;
+	skos:note "An Agreement Policy MUST contain at least one Permission or Prohibition rule, a Party with Assigner function, and a Party with Assignee function (in the same Permission or Prohibition). The Agreement Policy will grant the terms of the Policy from the Assigner to the Assignee."@en .
+
+:Assertion
+	a rdfs:Class , owl:Class, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:subClassOf :Policy ;
+	owl:disjointWith :Offer, :Privacy, :Request, :Set, :Ticket ;
+	rdfs:label "Assertion"@en ;
+	skos:definition "A Policy that asserts a Rule over an Asset from parties."@en ;
+	skos:note "For example, a party (an assignee or assigner) can claim what terms they have over an Asset. An Assertion Policy does not grant such permissions/prohibitions but only asserts the parties claims. An Assetion Policy  MUST contain a target Asset, a Party with any functional role, and at least one of a Permission or Prohibition rule."@en ;
+    skos:scopeNote "Non-Normative"@en .
+
+:Offer
+	a rdfs:Class , owl:Class, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:subClassOf :Policy ;
+	owl:disjointWith :Agreement, :Privacy, :Request, :Set, :Ticket, :Assertion ;
+	rdfs:label "Offer"@en ;
+	skos:definition "A Policy that proposes a Rule over an Asset from an assigner."@en ;
+	skos:note "An Offer Policy MUST contain at least one Permission or Prohibition rule and a Party with Assigner function (in the same Permission or Prohibition). The Offer Policy MAY contain a Party with Assignee function, but MUST not grant any privileges to that Party."@en .
+
+:Privacy
+	a rdfs:Class , owl:Class, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:subClassOf :Policy ;
+	owl:disjointWith :Agreement, :Offer, :Request, :Set, :Ticket, :Assertion ;
+	rdfs:label "Privacy Policy"@en ;
+	skos:definition "A Policy that expresses a Rule over an Asset containing personal information."@en ;
+	skos:note "A Privacy Policy  MUST contain a target Asset, a Party with Assigner  is, a Party with Assignee function, and at least one of a Permission or Prohibition rule that MUST include a Duty. The target Asset SHOULD contain or relate to personal information about the Assignee. The Duty MUST describe obligations on the Assigner about managing the Asset. The Assignee is being granted the terms of the Privacy policy from the Assigner."@en ;
+    skos:scopeNote "Non-Normative"@en .
+
+:Request
+	a rdfs:Class , owl:Class, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:subClassOf :Policy ;
+	owl:disjointWith :Agreement, :Offer, :Privacy, :Set, :Ticket, :Assertion ;
+	rdfs:label "Request"@en ;
+	skos:definition "A Policy that proposes a Rule over an Asset from an assignee."@en ;
+	skos:note "A Request Policy  MUST contain a target Asset, a Party with Assignee function, and at least one of a Permission or Prohibition rule. The Request MAY also contain the Party with Assigner function if this is known. No privileges are granted to any Party."@en ;
+    skos:scopeNote "Non-Normative"@en .
+
+:Set
+	a rdfs:Class , owl:Class, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:subClassOf :Policy ;
+	owl:disjointWith :Agreement, :Offer, :Privacy, :Request, :Ticket, :Assertion ;
+	rdfs:label "Set"@en ;
+	skos:definition "A Policy that expresses a Rule over an Asset."@en ;
+	skos:note "A Set Policy MUST contain a target Asset, and at least one Rule. A Set Policy is the default Policy subclass. The Set is aimed at scenarios where there is an open criteria for the semantics of the policy expressions and typically refined by other systems/profiles that process the information at a later time. No privileges are granted to any Party (if defined)."@en .
+
+:Ticket
+	a rdfs:Class , owl:Class, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:subClassOf :Policy ;
+	owl:disjointWith :Agreement, :Offer, :Privacy, :Request, :Set, :Assertion ;
+	rdfs:label "Ticket"@en ;
+	skos:definition "A Policy that grants the holder a Rule over an Asset from an assigner."@en ;
+	skos:note "A Ticket Policy MUST contain a target Asset and at least one of a Permission or Prohibition rule.  The Ticket MAY contain the Party with Assigner function and MUST NOT contain an Assignee. The Ticket Policy will grant the terms of the Policy to the holder of that Ticket. The holder of the Ticket MAY remain unknown or MAY have to be identified at some later stage."@en ;
+    skos:scopeNote "Non-Normative"@en .
+
+## Scopes
+
+:AssetScope
+	a rdfs:Class , owl:Class, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:label "Asset Scope"@en ;
+	skos:definition "Scopes for Asset Scope expressions."@en ;
+	skos:note "Instances of the AssetScope class represent the terms for the scope property of Assets."@en ;
+    owl:deprecated true .
+
+:PartyScope
+	a rdfs:Class , owl:Class, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:label "Party Scope"@en ;
+	skos:definition "Scopes for Party Scope expressions."@en ;
+	skos:note "Instances of the PartyScope class represent the terms for the scope property of Parties."@en ;
+    owl:deprecated true .
+
+:All
+	a :PartyScope, owl:NamedIndividual, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:label "All"@en ;
+	skos:definition "Specifies that the scope of the relationship is all of the collective individuals within a context."@en ;
+	skos:note "For example, may be used to indicate all the users of a specific social network the party is a member of. Note that “group” scope is also assumed."@en ;
+    skos:scopeNote "Non-Normative"@en ;
+    owl:deprecated true .
+
+:All2ndConnections
+	a :PartyScope, owl:NamedIndividual, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:label "All Second-level Connections"@en ;
+	skos:definition "Specifies that the scope of the relationship is all of the second-level connections to the Party."@en ;
+	skos:note "For example, may be used to indicate all “friends of friends” of the Party. Note that “group” scope is also assumed."@en ;
+    skos:scopeNote "Non-Normative"@en ;
+    owl:deprecated true .
+
+:AllConnections
+	a :PartyScope, owl:NamedIndividual, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:label "All First-Level Connections"@en ;
+	skos:definition "Specifies that the scope of the relationship is all of the first-level connections of the Party."@en ;
+	skos:note "For example, may be used to indicate all “friends” of the Party. Note that “group” scope is also assumed."@en ;
+    skos:scopeNote "Non-Normative"@en ;
+    owl:deprecated true .
+
+:AllGroups
+	a :PartyScope, owl:NamedIndividual, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:label "All Group Connections"@en ;
+	skos:definition "Specifies that the scope of the relationship is all of the group connections of the Party."@en ;
+	skos:note "For example, may be used to indicate all groups that the Party is a member of. Note that “group” scope is also assumed."@en ;
+    skos:scopeNote "Non-Normative"@en ;
+    owl:deprecated true .
+
+:Group
+	a :PartyScope, owl:NamedIndividual, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:label "Group"@en ;
+	skos:definition "Specifies that the scope of the relationship is the defined group with multiple individual members."@en ;
+    skos:scopeNote "Non-Normative"@en ;
+    owl:deprecated true .
+
+:Individual
+	a :PartyScope, owl:NamedIndividual, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:label "Individual"@en ;
+	skos:definition "Specifies that the scope of the relationship is the single Party individual."@en ;
+    owl:deprecated true .
+
+## Deprecated terms
+
+:adHocShare
+	a :Action, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:label "Ad-hoc sharing"@en ;
+	skos:definition "The act of sharing the asset to parties in close proximity to the owner."@en ;
+    skos:note "This original term and URI from the OMA specification should be used: http://www.openmobilealliance.com/oma-dd/adhoc-share ."@en ;
+    owl:deprecated true .
+
+:extractChar
+	a :Action, skos:Concept ;
+#	skos:broader :extract ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:label "Extract character"@en ;
+	skos:definition "The act of extracting (replicating) unchanged characters from the asset."@en ;
+ skos:note "This original term and URI from the ONIX specification should be used: http://www.editeur.org/onix-pl/extract-char ."@en ;
+  owl:deprecated true .
+
+:extractPage
+	a :Action, skos:Concept ;
+#	skos:broader :extract ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:label "Extract page"@en ;
+	skos:definition "The act of extracting (replicating) unchanged pages from the asset."@en ;
+ skos:note "This original term and URI from the ONIX specification should be used: http://www.editeur.org/onix-pl/extract-page ."@en ;
+    owl:deprecated true .
+
+
+:extractWord
+	a :Action, skos:Concept ;
+#	skos:broader :extract ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:label "Extract word"@en ;
+	skos:definition "The act of extracting (replicating) unchanged words from the asset."@en ;
+ skos:note "This original term and URI from the ONIX specification should be used: http://www.editeur.org/onix-pl/extract-word ."@en ;
+    owl:deprecated true .
+
+:attachPolicy
+	a :Action, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:label "Attach policy"@en ;
+	skos:definition "The act of keeping the policy notice with the asset."@en ;
+    owl:deprecated true ;
+	skos:exactMatch cc:Notice .
+
+:attachSource
+	a :Action, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:label "Attach source"@en ;
+	skos:definition "The act of attaching the source of the asset and its derivatives."@en ;
+    owl:deprecated true ;
+	skos:exactMatch cc:SourceCode .
+
+:shareAlike
+	a :Action, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:label "Share-alike"@en ;
+	skos:definition "The act of distributing any derivative asset under the same terms as the original asset."@en ;
+    owl:deprecated true ;
+	skos:exactMatch cc:ShareAlike .
+
+:commercialize
+	a :Action, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:label "Commercialize"@en ;
+	skos:definition "The act of using the asset in a business environment."@en ;
+    owl:deprecated true ;
+	skos:exactMatch cc:CommercialUse .
+
+:share
+	a :Action, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:label "Share"@en ;
+	skos:definition "The act of the non-commercial reproduction and distribution of the asset to third-parties."@en ;
+    owl:deprecated true ;
+	skos:exactMatch cc:Sharing .
+
+
+:proximity
+	a rdf:Property , owl:DatatypeProperty, skos:Concept ;
+##	rdfs:subPropertyOf :rightOperand ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:label "proximity"@en ;
+	skos:definition "An value indicating the closeness or nearness."@en ;
+    skos:note "This original term and URI from the OMA specification should be used: http://www.openmobilealliance.com/oma-dd/proximity ."@en ;
+    owl:deprecated true .
+
+:timedCount
+	a rdf:Property , owl:DatatypeProperty, skos:Concept ;
+##	rdfs:subPropertyOf :rightOperand ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:label "Timed Count"@en ;
+	skos:definition "The number of seconds after which timed metering use of the asset begins."@en ;
+	rdfs:range rdfs:Literal ;
+    skos:note "This original term and URI from the OMA specification should be used: http://www.openmobilealliance.com/oma-dd/timed-count ."@en ;
+    owl:deprecated true .
+
+## Collective Vocabulary
+
+cc:Reproduction
+	a :Action, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:label "Reproduction"@en ;
+	skos:definition "Making multiple copies."@en ;
+    skos:note "This term is defined by Creative Commons."@en ;
+	:includedIn odrl:use ;
+    skos:scopeNote "Non-Normative"@en .
+
+cc:Distribution
+	a :Action, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:label "Distribution"@en ;
+	skos:definition "Distribution, public display, and publicly performance."@en ;
+    skos:note "This term is defined by Creative Commons."@en ;
+	:includedIn odrl:use ;
+    skos:scopeNote "Non-Normative"@en .
+
+cc:DerivativeWorks
+	a :Action, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:label "Derivative Works"@en ;
+	skos:definition "Distribution of derivative works."@en ;
+    skos:note "This term is defined by Creative Commons."@en ;
+	:includedIn odrl:use ;
+    skos:scopeNote "Non-Normative"@en .
+
+cc:CommericalUse
+	a :Action, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:label "Commercial Use"@en ;
+	skos:definition "Exercising rights for commercial purposes."@en ;
+    skos:note "This term is defined by Creative Commons."@en ;
+	:includedIn odrl:use ;
+    skos:scopeNote "Non-Normative"@en .
+
+cc:Notice
+	a :Action, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:label "Notice"@en ;
+	skos:definition "Copyright and license notices be kept intact."@en ;
+    skos:note "This term is defined by Creative Commons."@en ;
+	:includedIn odrl:use ;
+    skos:scopeNote "Non-Normative"@en .
+
+cc:Attribution
+	a :Action, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:label "Attribution"@en ;
+	skos:definition "Credit be given to copyright holder and/or author."@en ;
+    skos:note "This term is defined by Creative Commons."@en ;
+	:includedIn odrl:use ;
+    skos:scopeNote "Non-Normative"@en .
+
+cc:ShareAlike
+	a :Action, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:label "Share Alike"@en ;
+	skos:definition "Derivative works be licensed under the same terms or compatible terms as the original work."@en ;
+    skos:note "This term is defined by Creative Commons."@en ;
+	:includedIn odrl:use ;
+    skos:scopeNote "Non-Normative"@en .
+
+cc:Sharing
+	a :Action, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:label "Sharing"@en ;
+	skos:definition "Permits commercial derivatives, but only non-commercial distribution."@en ;
+    skos:note "This term is defined by Creative Commons."@en ;
+	:includedIn odrl:use ;
+    skos:scopeNote "Non-Normative"@en .
+
+cc:SourceCode
+	a :Action, skos:Concept ;
+	rdfs:isDefinedBy odrl: ;
+	rdfs:label "Source Code"@en ;
+	skos:definition "Source code (the preferred form for making modifications) must be provided when exercising some rights granted by the license."@en ;
+    skos:note "This term is defined by Creative Commons."@en ;
+	:includedIn odrl:use ;
+    skos:scopeNote "Non-Normative"@en .
+
+
+## Axioms
+
+  dct:license rdfs:subPropertyOf odrl:hasPolicy .
+
+## Declaration of annotation properties to keep the ontology within OWL DL
+	skos:broader rdf:type owl:AnnotationProperty .
+	skos:member rdf:type owl:AnnotationProperty .
+	skos:note rdf:type owl:AnnotationProperty .
+	skos:scopeNote rdf:type owl:AnnotationProperty .
+	skos:prefLabel rdf:type owl:AnnotationProperty .
+	skos:definition rdf:type owl:AnnotationProperty .
+	skos:broaderTransitive rdf:type owl:AnnotationProperty .
+	skos:hasTopConcept rdf:type owl:AnnotationProperty .
+	dct:contributor rdf:type owl:AnnotationProperty .
+	dct:license rdf:type owl:AnnotationProperty .
+	dct:issued rdf:type owl:AnnotationProperty .
+	dct:subject rdf:type owl:AnnotationProperty .
+	dct:creator rdf:type owl:AnnotationProperty .
+	dct:description rdf:type owl:AnnotationProperty .
+	dct:isVersionOf rdf:type owl:AnnotationProperty .
+	dct:format rdf:type owl:AnnotationProperty .
+	skos:Collection a owl:Class .	
+	skos:Concept a owl:Class .	
+	skos:ConceptScheme a owl:Class .	
+
+	

--- a/vocab/ODRL22.rdf
+++ b/vocab/ODRL22.rdf
@@ -1,0 +1,2611 @@
+<?xml version="1.0" encoding="utf-8"?>
+<rdf:RDF
+  xmlns:owl="http://www.w3.org/2002/07/owl#"
+  xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+  xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+  xmlns:odrl="http://www.w3.org/ns/odrl/2/"
+  xmlns:dct="http://purl.org/dc/terms/"
+  xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+>
+  <skos:Collection rdf:about="http://www.w3.org/ns/odrl/2/#policySubClassesCommon">
+    <skos:member rdf:resource="http://www.w3.org/ns/odrl/2/Assertion"/>
+    <skos:scopeNote xml:lang="en">ODRL Common Vocabulary Terms</skos:scopeNote>
+    <skos:prefLabel xml:lang="en">Policy Subclasses</skos:prefLabel>
+    <skos:member rdf:resource="http://www.w3.org/ns/odrl/2/Privacy"/>
+    <skos:member rdf:resource="http://www.w3.org/ns/odrl/2/Request"/>
+    <skos:member rdf:resource="http://www.w3.org/ns/odrl/2/Ticket"/>
+  </skos:Collection>
+  <skos:Collection rdf:about="http://www.w3.org/ns/odrl/2/#actionsCommon">
+    <skos:member>
+      <odrl:Action rdf:about="http://creativecommons.org/ns#Attribution">
+        <odrl:includedIn rdf:resource="http://www.w3.org/ns/odrl/2/use"/>
+        <skos:scopeNote xml:lang="en">Non-Normative</skos:scopeNote>
+        <skos:note xml:lang="en">This term is defined by Creative Commons.</skos:note>
+        <skos:definition xml:lang="en">Credit be given to copyright holder and/or author.</skos:definition>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <rdfs:label xml:lang="en">Attribution</rdfs:label>
+      </odrl:Action>
+    </skos:member>
+    <skos:scopeNote xml:lang="en">ODRL Common Vocabulary Terms</skos:scopeNote>
+    <skos:member>
+      <odrl:Action rdf:about="http://www.w3.org/ns/odrl/2/stream">
+        <skos:note>The Asset maybe utilised in real-time as it is being delivered. If the action is to be performed to a wider audience than just the Assignees, then the Recipient constraint is recommended to be used.</skos:note>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <rdfs:label xml:lang="en">Stream</rdfs:label>
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <skos:definition xml:lang="en">To deliver the Asset in real-time.</skos:definition>
+        <odrl:includedIn rdf:resource="http://www.w3.org/ns/odrl/2/use"/>
+        <skos:scopeNote xml:lang="en">Non-Normative</skos:scopeNote>
+      </odrl:Action>
+    </skos:member>
+    <skos:member>
+      <odrl:Action rdf:about="http://www.w3.org/ns/odrl/2/obtainConsent">
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <skos:note xml:lang="en">May be used as a Duty to ensure that the Assigner or a Party is authorized to approve such actions on a case-by-case basis. May link to a Party with the role “consentingParty” function.</skos:note>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <skos:definition xml:lang="en">To obtain verifiable consent to perform the requested action in relation to the Asset.</skos:definition>
+        <rdfs:label xml:lang="en">Obtain Consent</rdfs:label>
+        <odrl:includedIn rdf:resource="http://www.w3.org/ns/odrl/2/use"/>
+        <skos:scopeNote xml:lang="en">Non-Normative</skos:scopeNote>
+      </odrl:Action>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://www.w3.org/ns/odrl/2/delete">
+        <skos:definition xml:lang="en">To permanently remove all copies of the Asset after it has been used.</skos:definition>
+        <rdf:type rdf:resource="http://www.w3.org/ns/odrl/2/Action"/>
+        <skos:scopeNote xml:lang="en">Non-Normative</skos:scopeNote>
+        <odrl:includedIn rdf:resource="http://www.w3.org/ns/odrl/2/use"/>
+        <skos:note xml:lang="en">Use a constraint to define under which conditions the Asset must be deleted.</skos:note>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <rdfs:label xml:lang="en">Delete</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <odrl:Action rdf:about="http://www.w3.org/ns/odrl/2/ensureExclusivity">
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <skos:note xml:lang="en">If used as a Duty, the assignee should be explicitly indicated as the party that is ensuring the exclusivity of the Rule.</skos:note>
+        <skos:scopeNote xml:lang="en">Non-Normative</skos:scopeNote>
+        <odrl:includedIn rdf:resource="http://www.w3.org/ns/odrl/2/use"/>
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <skos:definition xml:lang="en">To ensure that the Rule on the Asset is exclusive.</skos:definition>
+        <rdfs:label xml:lang="en">Ensure Exclusivity</rdfs:label>
+      </odrl:Action>
+    </skos:member>
+    <skos:member>
+      <odrl:Action rdf:about="http://creativecommons.org/ns#ShareAlike">
+        <skos:definition xml:lang="en">Derivative works be licensed under the same terms or compatible terms as the original work.</skos:definition>
+        <odrl:includedIn rdf:resource="http://www.w3.org/ns/odrl/2/use"/>
+        <skos:scopeNote xml:lang="en">Non-Normative</skos:scopeNote>
+        <rdfs:label xml:lang="en">Share Alike</rdfs:label>
+        <skos:note xml:lang="en">This term is defined by Creative Commons.</skos:note>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+      </odrl:Action>
+    </skos:member>
+    <skos:member>
+      <odrl:Action rdf:about="http://www.w3.org/ns/odrl/2/inform">
+        <odrl:includedIn rdf:resource="http://www.w3.org/ns/odrl/2/use"/>
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <skos:scopeNote xml:lang="en">Non-Normative</skos:scopeNote>
+        <rdfs:label xml:lang="en">Inform</rdfs:label>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <skos:definition xml:lang="en">To inform that an action has been performed on or in relation to the Asset.</skos:definition>
+        <skos:note xml:lang="en">May link to a Party with the role 'informedParty' function.</skos:note>
+      </odrl:Action>
+    </skos:member>
+    <skos:member>
+      <odrl:Action rdf:about="http://www.w3.org/ns/odrl/2/acceptTracking">
+        <odrl:includedIn rdf:resource="http://www.w3.org/ns/odrl/2/use"/>
+        <skos:definition xml:lang="en">To accept that the use of the Asset may be tracked.</skos:definition>
+        <skos:note xml:lang="en">The collected information may be tracked by the Assigner, or may link to a Party with the role 'trackingParty' function.</skos:note>
+        <rdfs:label xml:lang="en">Accept Tracking</rdfs:label>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <skos:scopeNote xml:lang="en">Non-Normative</skos:scopeNote>
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+      </odrl:Action>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://www.w3.org/ns/odrl/2/grantUse">
+        <rdfs:label xml:lang="en">Grant Use</rdfs:label>
+        <skos:note xml:lang="en">This action enables the assignee to create policies for the use of the Asset for third parties. The nextPolicy is recommended to be agreed with the third party. Use of temporal constraints is recommended.</skos:note>
+        <skos:definition xml:lang="en">To grant the use of the Asset to third parties.</skos:definition>
+        <skos:scopeNote xml:lang="en">Non-Normative</skos:scopeNote>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <rdf:type rdf:resource="http://www.w3.org/ns/odrl/2/Action"/>
+        <odrl:includedIn rdf:resource="http://www.w3.org/ns/odrl/2/use"/>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <odrl:Action rdf:about="http://www.w3.org/ns/odrl/2/concurrentUse">
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <skos:scopeNote xml:lang="en">Non-Normative</skos:scopeNote>
+        <skos:definition xml:lang="en">To create multiple copies of the Asset that are being concurrently used.</skos:definition>
+        <rdfs:label xml:lang="en">Concurrent Use</rdfs:label>
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <odrl:includedIn rdf:resource="http://www.w3.org/ns/odrl/2/use"/>
+      </odrl:Action>
+    </skos:member>
+    <skos:member>
+      <odrl:Action rdf:about="http://www.w3.org/ns/odrl/2/nextPolicy">
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <skos:definition xml:lang="en">To grant the specified Policy to a third party for their use of the Asset.</skos:definition>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <skos:scopeNote xml:lang="en">Non-Normative</skos:scopeNote>
+        <skos:note xml:lang="en">Useful for downstream policies.</skos:note>
+        <rdfs:label xml:lang="en">Next Policy</rdfs:label>
+        <odrl:includedIn rdf:resource="http://www.w3.org/ns/odrl/2/use"/>
+      </odrl:Action>
+    </skos:member>
+    <skos:member>
+      <odrl:Action rdf:about="http://www.w3.org/ns/odrl/2/distribute">
+        <skos:note xml:lang="en">It is recommended to use nextPolicy to express the allowable usages by third-parties.</skos:note>
+        <rdfs:label xml:lang="en">Distribute</rdfs:label>
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <odrl:includedIn rdf:resource="http://www.w3.org/ns/odrl/2/use"/>
+        <skos:definition xml:lang="en">To supply the Asset to third-parties.</skos:definition>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <skos:scopeNote xml:lang="en">Non-Normative</skos:scopeNote>
+      </odrl:Action>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://www.w3.org/ns/odrl/2/archive">
+        <rdf:type rdf:resource="http://www.w3.org/ns/odrl/2/Action"/>
+        <odrl:includedIn rdf:resource="http://www.w3.org/ns/odrl/2/use"/>
+        <rdfs:label xml:lang="en">Archive</rdfs:label>
+        <skos:definition xml:lang="en">To store the Asset (in a non-transient form).</skos:definition>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <skos:note xml:lang="en">Temporal constraints may be used for temporal conditions.</skos:note>
+        <skos:scopeNote xml:lang="en">Non-Normative</skos:scopeNote>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://www.w3.org/ns/odrl/2/attribute">
+        <skos:scopeNote xml:lang="en">Non-Normative</skos:scopeNote>
+        <rdfs:label xml:lang="en">Attribute</rdfs:label>
+        <odrl:includedIn rdf:resource="http://www.w3.org/ns/odrl/2/use"/>
+        <skos:definition xml:lang="en">To attribute the use of the Asset.</skos:definition>
+        <skos:note xml:lang="en">May link to an Asset with the attribution information. May link to a Party with the  role “attributedParty” function.</skos:note>
+        <rdf:type rdf:resource="http://www.w3.org/ns/odrl/2/Action"/>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <odrl:Action rdf:about="http://www.w3.org/ns/odrl/2/uninstall">
+        <rdfs:label xml:lang="en">Uninstall</rdfs:label>
+        <odrl:includedIn rdf:resource="http://www.w3.org/ns/odrl/2/use"/>
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <skos:note xml:lang="en">The Asset is no longer accessible to the assignees after it has been used.</skos:note>
+        <skos:definition xml:lang="en">To unload and delete the computer program Asset from a storage device and disable its readiness for operation.</skos:definition>
+        <skos:scopeNote xml:lang="en">Non-Normative</skos:scopeNote>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+      </odrl:Action>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://www.w3.org/ns/odrl/2/digitize">
+        <rdfs:label xml:lang="en">Digitize</rdfs:label>
+        <skos:definition xml:lang="en">To produce a digital copy of (or otherwise digitize) the Asset from its analogue form.</skos:definition>
+        <rdf:type rdf:resource="http://www.w3.org/ns/odrl/2/Action"/>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <skos:scopeNote xml:lang="en">Non-Normative</skos:scopeNote>
+        <odrl:includedIn rdf:resource="http://www.w3.org/ns/odrl/2/use"/>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://creativecommons.org/ns#Distribution">
+        <skos:definition xml:lang="en">Distribution, public display, and publicly performance.</skos:definition>
+        <skos:note xml:lang="en">This term is defined by Creative Commons.</skos:note>
+        <skos:scopeNote xml:lang="en">Non-Normative</skos:scopeNote>
+        <rdf:type rdf:resource="http://www.w3.org/ns/odrl/2/Action"/>
+        <rdfs:label xml:lang="en">Distribution</rdfs:label>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <odrl:includedIn rdf:resource="http://www.w3.org/ns/odrl/2/use"/>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://www.w3.org/ns/odrl/2/present">
+        <skos:note>The asset can be performed (or communicated) in public.</skos:note>
+        <rdf:type rdf:resource="http://www.w3.org/ns/odrl/2/Action"/>
+        <odrl:includedIn rdf:resource="http://www.w3.org/ns/odrl/2/use"/>
+        <rdfs:label xml:lang="en">Present</rdfs:label>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <skos:scopeNote xml:lang="en">Non-Normative</skos:scopeNote>
+        <skos:definition xml:lang="en">To publicly perform the Asset.</skos:definition>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <odrl:Action rdf:about="http://www.w3.org/ns/odrl/2/print">
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <skos:scopeNote xml:lang="en">Non-Normative</skos:scopeNote>
+        <skos:note xml:lang="en">For example, creating a permanent, fixed (static), and directly perceivable representation of the Asset, such as printing onto paper.</skos:note>
+        <odrl:includedIn rdf:resource="http://www.w3.org/ns/odrl/2/use"/>
+        <rdfs:label xml:lang="en">Print</rdfs:label>
+        <skos:definition xml:lang="en">To create a tangible and permanent rendition of an Asset.</skos:definition>
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+      </odrl:Action>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://www.w3.org/ns/odrl/2/play">
+        <skos:definition xml:lang="en">To create a sequential and transient rendition of an Asset.</skos:definition>
+        <rdf:type rdf:resource="http://www.w3.org/ns/odrl/2/Action"/>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <skos:scopeNote xml:lang="en">Non-Normative</skos:scopeNote>
+        <skos:note>For example, to play a video or audio track. If the action is to be performed to a wider audience than just the Assignees, then the Recipient constraint is recommended to be used.</skos:note>
+        <rdfs:label xml:lang="en">Play</rdfs:label>
+        <odrl:includedIn rdf:resource="http://www.w3.org/ns/odrl/2/use"/>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <odrl:Action rdf:about="http://www.w3.org/ns/odrl/2/execute">
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <skos:definition xml:lang="en">To run the computer program Asset.</skos:definition>
+        <skos:note xml:lang="en">For example, machine executable code or Java such as a game or application.</skos:note>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <skos:scopeNote xml:lang="en">Non-Normative</skos:scopeNote>
+        <rdfs:label xml:lang="en">Execute</rdfs:label>
+        <odrl:includedIn rdf:resource="http://www.w3.org/ns/odrl/2/use"/>
+      </odrl:Action>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://creativecommons.org/ns#CommericalUse">
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <skos:scopeNote xml:lang="en">Non-Normative</skos:scopeNote>
+        <skos:definition xml:lang="en">Exercising rights for commercial purposes.</skos:definition>
+        <rdf:type rdf:resource="http://www.w3.org/ns/odrl/2/Action"/>
+        <odrl:includedIn rdf:resource="http://www.w3.org/ns/odrl/2/use"/>
+        <rdfs:label xml:lang="en">Commercial Use</rdfs:label>
+        <skos:note xml:lang="en">This term is defined by Creative Commons.</skos:note>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://www.w3.org/ns/odrl/2/extract">
+        <rdfs:label xml:lang="en">Extract</rdfs:label>
+        <rdf:type rdf:resource="http://www.w3.org/ns/odrl/2/Action"/>
+        <skos:note xml:lang="en">A new asset is created and may have very little in common with the original Asset. (Note that the notion of whether or not the change is significant enough to qualify as a new asset is subjective). To the extracted Asset a next policy may be applied.</skos:note>
+        <skos:definition xml:lang="en">To extract parts of the Asset and to use it as a new Asset.</skos:definition>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <odrl:includedIn rdf:resource="http://www.w3.org/ns/odrl/2/reproduce"/>
+        <skos:scopeNote xml:lang="en">Non-Normative</skos:scopeNote>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <odrl:Action rdf:about="http://www.w3.org/ns/odrl/2/watermark">
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <skos:scopeNote xml:lang="en">Non-Normative</skos:scopeNote>
+        <rdfs:label xml:lang="en">Watermark</rdfs:label>
+        <skos:definition xml:lang="en">To apply a watermark to the Asset.</skos:definition>
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <odrl:includedIn rdf:resource="http://www.w3.org/ns/odrl/2/use"/>
+      </odrl:Action>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://www.w3.org/ns/odrl/2/give">
+        <rdfs:label xml:lang="en">Give</rdfs:label>
+        <skos:definition xml:lang="en">To transfer the ownership of the Asset to a third party without compensation and while deleting the original asset.</skos:definition>
+        <rdf:type rdf:resource="http://www.w3.org/ns/odrl/2/Action"/>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <skos:scopeNote xml:lang="en">Non-Normative</skos:scopeNote>
+        <odrl:includedIn rdf:resource="http://www.w3.org/ns/odrl/2/transfer"/>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <odrl:Action rdf:about="http://www.w3.org/ns/odrl/2/aggregate">
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <skos:scopeNote xml:lang="en">Non-Normative</skos:scopeNote>
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <skos:definition xml:lang="en">To use the Asset or parts of it as part of a composite collection.</skos:definition>
+        <odrl:includedIn rdf:resource="http://www.w3.org/ns/odrl/2/use"/>
+        <rdfs:label xml:lang="en">Aggregate</rdfs:label>
+      </odrl:Action>
+    </skos:member>
+    <skos:member>
+      <odrl:Action rdf:about="http://creativecommons.org/ns#DerivativeWorks">
+        <skos:definition xml:lang="en">Distribution of derivative works.</skos:definition>
+        <rdfs:label xml:lang="en">Derivative Works</rdfs:label>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <skos:scopeNote xml:lang="en">Non-Normative</skos:scopeNote>
+        <skos:note xml:lang="en">This term is defined by Creative Commons.</skos:note>
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <odrl:includedIn rdf:resource="http://www.w3.org/ns/odrl/2/use"/>
+      </odrl:Action>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://www.w3.org/ns/odrl/2/include">
+        <rdf:type rdf:resource="http://www.w3.org/ns/odrl/2/Action"/>
+        <skos:definition xml:lang="en">To include other related assets in the Asset.</skos:definition>
+        <odrl:includedIn rdf:resource="http://www.w3.org/ns/odrl/2/use"/>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <skos:scopeNote xml:lang="en">Non-Normative</skos:scopeNote>
+        <rdfs:label xml:lang="en">Include</rdfs:label>
+        <skos:note xml:lang="en">For example: bio picture must be included in the attribution. Use of a relation sub-property is required for the related assets.</skos:note>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <odrl:Action rdf:about="http://www.w3.org/ns/odrl/2/textToSpeech">
+        <skos:scopeNote xml:lang="en">Non-Normative</skos:scopeNote>
+        <rdfs:label xml:lang="en">Text-to-speech</rdfs:label>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <skos:definition xml:lang="en">To have a text Asset read out loud.</skos:definition>
+        <skos:note>If the action is to be performed to a wider audience than just the Assignees, then the recipient constraint is recommended to be used.</skos:note>
+        <odrl:includedIn rdf:resource="http://www.w3.org/ns/odrl/2/use"/>
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+      </odrl:Action>
+    </skos:member>
+    <skos:member>
+      <odrl:Action rdf:about="http://www.w3.org/ns/odrl/2/transform">
+        <skos:definition xml:lang="en">To convert the Asset into a different format.</skos:definition>
+        <skos:note xml:lang="en">Typically used to convert the Asset into a different format for consumption on/transfer to a third party system.</skos:note>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <skos:scopeNote xml:lang="en">Non-Normative</skos:scopeNote>
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <odrl:includedIn rdf:resource="http://www.w3.org/ns/odrl/2/use"/>
+        <rdfs:label xml:lang="en">Transform</rdfs:label>
+      </odrl:Action>
+    </skos:member>
+    <skos:member>
+      <odrl:Action rdf:about="http://www.w3.org/ns/odrl/2/modify">
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <skos:scopeNote xml:lang="en">Non-Normative</skos:scopeNote>
+        <skos:definition xml:lang="en">To change existing content of the Asset. A new asset is not created by this action.</skos:definition>
+        <skos:note xml:lang="en">This action will modify an asset which is typically updated from time to time without creating a new asset. If the result from modifying the asset should be a new asset the actions derive or extract should be used. (Note that the notion of whether or not the change is significant enough to qualify as a new asset is subjective).</skos:note>
+        <odrl:includedIn rdf:resource="http://www.w3.org/ns/odrl/2/use"/>
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <rdfs:label xml:lang="en">Modify</rdfs:label>
+      </odrl:Action>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://www.w3.org/ns/odrl/2/synchronize">
+        <odrl:includedIn rdf:resource="http://www.w3.org/ns/odrl/2/use"/>
+        <rdfs:label xml:lang="en">Synchronize</rdfs:label>
+        <skos:scopeNote xml:lang="en">Non-Normative</skos:scopeNote>
+        <skos:definition xml:lang="en">To use the Asset in timed relations with media (audio/visual) elements of another Asset.</skos:definition>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <rdf:type rdf:resource="http://www.w3.org/ns/odrl/2/Action"/>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://www.w3.org/ns/odrl/2/index">
+        <rdf:type rdf:resource="http://www.w3.org/ns/odrl/2/Action"/>
+        <odrl:includedIn rdf:resource="http://www.w3.org/ns/odrl/2/use"/>
+        <rdfs:label xml:lang="en">Index</rdfs:label>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <skos:scopeNote xml:lang="en">Non-Normative</skos:scopeNote>
+        <skos:definition xml:lang="en">To record the Asset in an index.</skos:definition>
+        <skos:note xml:lang="en">For example, to include a link to the Asset in a search engine database.</skos:note>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://www.w3.org/ns/odrl/2/annotate">
+        <skos:definition xml:lang="en">To add explanatory notations/commentaries to the Asset without modifying the Asset in any other way.</skos:definition>
+        <odrl:includedIn rdf:resource="http://www.w3.org/ns/odrl/2/use"/>
+        <rdf:type rdf:resource="http://www.w3.org/ns/odrl/2/Action"/>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <skos:scopeNote xml:lang="en">Non-Normative</skos:scopeNote>
+        <rdfs:label xml:lang="en">Annotate</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <odrl:Action rdf:about="http://www.w3.org/ns/odrl/2/reviewPolicy">
+        <skos:note xml:lang="en">Used when human intervention is required to review the Policy. May link to an Asset which represents the full Policy information.</skos:note>
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <odrl:includedIn rdf:resource="http://www.w3.org/ns/odrl/2/use"/>
+        <rdfs:label xml:lang="en">Review Policy</rdfs:label>
+        <skos:definition xml:lang="en">To review the Policy applicable to the Asset.</skos:definition>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <skos:scopeNote xml:lang="en">Non-Normative</skos:scopeNote>
+      </odrl:Action>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://www.w3.org/ns/odrl/2/move">
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <rdf:type rdf:resource="http://www.w3.org/ns/odrl/2/Action"/>
+        <skos:definition xml:lang="en">To move the Asset from one digital location to another including deleting the original copy.</skos:definition>
+        <odrl:includedIn rdf:resource="http://www.w3.org/ns/odrl/2/use"/>
+        <skos:note xml:lang="en">After the Asset has been moved, the original copy must be deleted.</skos:note>
+        <skos:scopeNote xml:lang="en">Non-Normative</skos:scopeNote>
+        <rdfs:label xml:lang="en">Move</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://creativecommons.org/ns#Reproduction">
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <skos:definition xml:lang="en">Making multiple copies.</skos:definition>
+        <rdf:type rdf:resource="http://www.w3.org/ns/odrl/2/Action"/>
+        <odrl:includedIn rdf:resource="http://www.w3.org/ns/odrl/2/use"/>
+        <skos:note xml:lang="en">This term is defined by Creative Commons.</skos:note>
+        <skos:scopeNote xml:lang="en">Non-Normative</skos:scopeNote>
+        <rdfs:label xml:lang="en">Reproduction</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <odrl:Action rdf:about="http://www.w3.org/ns/odrl/2/install">
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <rdfs:label xml:lang="en">Install</rdfs:label>
+        <skos:definition xml:lang="en">To load the computer program Asset onto a storage device which allows operating or running the Asset.</skos:definition>
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <odrl:includedIn rdf:resource="http://www.w3.org/ns/odrl/2/use"/>
+        <skos:scopeNote xml:lang="en">Non-Normative</skos:scopeNote>
+      </odrl:Action>
+    </skos:member>
+    <skos:member>
+      <odrl:Action rdf:about="http://creativecommons.org/ns#SourceCode">
+        <odrl:includedIn rdf:resource="http://www.w3.org/ns/odrl/2/use"/>
+        <skos:definition xml:lang="en">Source code (the preferred form for making modifications) must be provided when exercising some rights granted by the license.</skos:definition>
+        <skos:scopeNote xml:lang="en">Non-Normative</skos:scopeNote>
+        <rdfs:label xml:lang="en">Source Code</rdfs:label>
+        <skos:note xml:lang="en">This term is defined by Creative Commons.</skos:note>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+      </odrl:Action>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://www.w3.org/ns/odrl/2/anonymize">
+        <odrl:includedIn rdf:resource="http://www.w3.org/ns/odrl/2/use"/>
+        <skos:definition xml:lang="en">To anonymize all or parts of the Asset.</skos:definition>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <rdf:type rdf:resource="http://www.w3.org/ns/odrl/2/Action"/>
+        <rdfs:label xml:lang="en">Anonymize</rdfs:label>
+        <skos:scopeNote xml:lang="en">Non-Normative</skos:scopeNote>
+        <skos:note xml:lang="en">For example, to remove identifying particulars for statistical or for other comparable purposes, or to use the Asset without stating the author/source.</skos:note>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://www.w3.org/ns/odrl/2/derive">
+        <skos:note xml:lang="en">A new asset is created and may have significant overlaps with the original Asset. (Note that the notion of whether or not the change is significant enough to qualify as a new asset is subjective). To the derived Asset a next policy may be applied.</skos:note>
+        <odrl:includedIn rdf:resource="http://www.w3.org/ns/odrl/2/use"/>
+        <rdfs:label xml:lang="en">Derive</rdfs:label>
+        <rdf:type rdf:resource="http://www.w3.org/ns/odrl/2/Action"/>
+        <skos:definition xml:lang="en">To create a new derivative Asset from this Asset and to edit or modify the derivative.</skos:definition>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <skos:scopeNote xml:lang="en">Non-Normative</skos:scopeNote>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <odrl:Action rdf:about="http://www.w3.org/ns/odrl/2/sell">
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <odrl:includedIn rdf:resource="http://www.w3.org/ns/odrl/2/transfer"/>
+        <skos:scopeNote xml:lang="en">Non-Normative</skos:scopeNote>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <skos:definition xml:lang="en">To transfer the ownership of the Asset to a third party with compensation and while deleting the original asset.</skos:definition>
+        <rdfs:label xml:lang="en">Sell</rdfs:label>
+      </odrl:Action>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://www.w3.org/ns/odrl/2/display">
+        <skos:definition xml:lang="en">To create a static and transient rendition of an Asset.</skos:definition>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <rdfs:label xml:lang="en">Display</rdfs:label>
+        <skos:note xml:lang="en">For example, displaying an image on a screen. If the action is to be performed to a wider audience than just the Assignees, then the Recipient constraint is recommended to be used.</skos:note>
+        <odrl:includedIn rdf:resource="http://www.w3.org/ns/odrl/2/play"/>
+        <skos:scopeNote xml:lang="en">Non-Normative</skos:scopeNote>
+        <rdf:type rdf:resource="http://www.w3.org/ns/odrl/2/Action"/>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <odrl:Action rdf:about="http://creativecommons.org/ns#Notice">
+        <skos:scopeNote xml:lang="en">Non-Normative</skos:scopeNote>
+        <skos:note xml:lang="en">This term is defined by Creative Commons.</skos:note>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <rdfs:label xml:lang="en">Notice</rdfs:label>
+        <odrl:includedIn rdf:resource="http://www.w3.org/ns/odrl/2/use"/>
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <skos:definition xml:lang="en">Copyright and license notices be kept intact.</skos:definition>
+      </odrl:Action>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://www.w3.org/ns/odrl/2/read">
+        <skos:note xml:lang="en">For example, the ability to read a record from a database (the Asset).</skos:note>
+        <skos:scopeNote xml:lang="en">Non-Normative</skos:scopeNote>
+        <rdfs:label xml:lang="en">Read</rdfs:label>
+        <odrl:includedIn rdf:resource="http://www.w3.org/ns/odrl/2/use"/>
+        <skos:definition xml:lang="en">To obtain data from the Asset.</skos:definition>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <rdf:type rdf:resource="http://www.w3.org/ns/odrl/2/Action"/>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <odrl:Action rdf:about="http://www.w3.org/ns/odrl/2/translate">
+        <rdfs:label xml:lang="en">Translate</rdfs:label>
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <odrl:includedIn rdf:resource="http://www.w3.org/ns/odrl/2/use"/>
+        <skos:scopeNote xml:lang="en">Non-Normative</skos:scopeNote>
+        <skos:note xml:lang="en">A new derivative Asset is created by that action.</skos:note>
+        <skos:definition xml:lang="en">To translate the original natural language of an Asset into another natural language.</skos:definition>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+      </odrl:Action>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://www.w3.org/ns/odrl/2/reproduce">
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <skos:scopeNote xml:lang="en">Non-Normative</skos:scopeNote>
+        <skos:definition xml:lang="en">To make duplicate copies the Asset in any material form.</skos:definition>
+        <rdfs:label xml:lang="en">Reproduce</rdfs:label>
+        <rdf:type rdf:resource="http://www.w3.org/ns/odrl/2/Action"/>
+        <odrl:includedIn rdf:resource="http://www.w3.org/ns/odrl/2/use"/>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <odrl:Action rdf:about="http://www.w3.org/ns/odrl/2/compensate">
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <skos:scopeNote xml:lang="en">Non-Normative</skos:scopeNote>
+        <skos:note xml:lang="en">The compensation may use different types of things with a value: (i) the thing is expressed by the value (term) of the Constraint name; (b) the value is expressed by operator, rightOperand, dataType and unit. Typically the assignee will compensate the assigner, but other compensation party roles may be used.</skos:note>
+        <rdfs:label xml:lang="en">Compensate</rdfs:label>
+        <odrl:includedIn rdf:resource="http://www.w3.org/ns/odrl/2/use"/>
+        <skos:definition xml:lang="en">To compensate by transfer of some amount of value, if defined, for using or selling the Asset.</skos:definition>
+      </odrl:Action>
+    </skos:member>
+    <skos:member>
+      <odrl:Action rdf:about="http://creativecommons.org/ns#Sharing">
+        <skos:note xml:lang="en">This term is defined by Creative Commons.</skos:note>
+        <odrl:includedIn rdf:resource="http://www.w3.org/ns/odrl/2/use"/>
+        <rdfs:label xml:lang="en">Sharing</rdfs:label>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <skos:definition xml:lang="en">Permits commercial derivatives, but only non-commercial distribution.</skos:definition>
+        <skos:scopeNote xml:lang="en">Non-Normative</skos:scopeNote>
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+      </odrl:Action>
+    </skos:member>
+    <skos:prefLabel xml:lang="en">Actions for Rules</skos:prefLabel>
+  </skos:Collection>
+  <skos:Collection rdf:about="http://www.w3.org/ns/odrl/2/#partyRolesCommon">
+    <skos:member>
+      <rdf:Property rdf:about="http://www.w3.org/ns/odrl/2/informingParty">
+        <skos:definition xml:lang="en">The Party who provides the inform use data.</skos:definition>
+        <skos:note xml:lang="en">Maybe specified as part of the inform action.</skos:note>
+        <rdfs:subPropertyOf rdf:resource="http://www.w3.org/ns/odrl/2/function"/>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <rdfs:label xml:lang="en">Informing Party</rdfs:label>
+        <skos:scopeNote xml:lang="en">Non-Normative</skos:scopeNote>
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+      </rdf:Property>
+    </skos:member>
+    <skos:member>
+      <rdf:Property rdf:about="http://www.w3.org/ns/odrl/2/attributedParty">
+        <skos:scopeNote xml:lang="en">Non-Normative</skos:scopeNote>
+        <rdfs:subPropertyOf rdf:resource="http://www.w3.org/ns/odrl/2/function"/>
+        <skos:note xml:lang="en">Maybe specified as part of the attribute action.</skos:note>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <rdfs:label xml:lang="en">Attributed Party</rdfs:label>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+        <skos:definition xml:lang="en">The Party to be attributed.</skos:definition>
+      </rdf:Property>
+    </skos:member>
+    <skos:member>
+      <owl:ObjectProperty rdf:about="http://www.w3.org/ns/odrl/2/compensatingParty">
+        <skos:note xml:lang="en">Maybe specified as part of the compensate duty action.</skos:note>
+        <skos:definition xml:lang="en">The Party that is the provider of the compensation.</skos:definition>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <rdfs:label xml:lang="en">Compensating Party</rdfs:label>
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <rdfs:subPropertyOf rdf:resource="http://www.w3.org/ns/odrl/2/function"/>
+        <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+        <skos:scopeNote xml:lang="en">Non-Normative</skos:scopeNote>
+      </owl:ObjectProperty>
+    </skos:member>
+    <skos:scopeNote xml:lang="en">ODRL Common Vocabulary Terms</skos:scopeNote>
+    <skos:member>
+      <rdf:Property rdf:about="http://www.w3.org/ns/odrl/2/contractedParty">
+        <skos:definition xml:lang="en">The Party who is being contracted.</skos:definition>
+        <rdfs:label xml:lang="en">Contracted Party</rdfs:label>
+        <rdfs:subPropertyOf rdf:resource="http://www.w3.org/ns/odrl/2/function"/>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <skos:scopeNote xml:lang="en">Non-Normative</skos:scopeNote>
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+      </rdf:Property>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://www.w3.org/ns/odrl/2/informedParty">
+        <rdfs:label xml:lang="en">Informed Party</rdfs:label>
+        <skos:note xml:lang="en">Maybe specified as part of the inform action.</skos:note>
+        <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <skos:scopeNote xml:lang="en">Non-Normative</skos:scopeNote>
+        <rdfs:subPropertyOf rdf:resource="http://www.w3.org/ns/odrl/2/function"/>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+        <skos:definition xml:lang="en">The Party to be informed of all uses.</skos:definition>
+      </skos:Concept>
+    </skos:member>
+    <skos:prefLabel xml:lang="en">Party Functions</skos:prefLabel>
+    <skos:member>
+      <skos:Concept rdf:about="http://www.w3.org/ns/odrl/2/contractingParty">
+        <rdfs:label xml:lang="en">Contracting Party</rdfs:label>
+        <skos:definition xml:lang="en">The Party who is offering the contract.</skos:definition>
+        <rdfs:subPropertyOf rdf:resource="http://www.w3.org/ns/odrl/2/function"/>
+        <skos:scopeNote xml:lang="en">Non-Normative</skos:scopeNote>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+        <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <rdf:Property rdf:about="http://www.w3.org/ns/odrl/2/compensatedParty">
+        <rdfs:subPropertyOf rdf:resource="http://www.w3.org/ns/odrl/2/function"/>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+        <skos:definition xml:lang="en">The Party is the recipient of the compensation.</skos:definition>
+        <rdfs:label xml:lang="en">Compensated Party</rdfs:label>
+        <skos:scopeNote xml:lang="en">Non-Normative</skos:scopeNote>
+        <skos:note xml:lang="en">Maybe specified as part of the compensate duty action.</skos:note>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+      </rdf:Property>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://www.w3.org/ns/odrl/2/attributingParty">
+        <rdfs:subPropertyOf rdf:resource="http://www.w3.org/ns/odrl/2/function"/>
+        <skos:definition xml:lang="en">The Party who undertakes the attribution.</skos:definition>
+        <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+        <skos:scopeNote xml:lang="en">Non-Normative</skos:scopeNote>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+        <rdfs:label xml:lang="en">Attributing Party</rdfs:label>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <skos:note xml:lang="en">Maybe specified as part of the attribute action.</skos:note>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <owl:ObjectProperty rdf:about="http://www.w3.org/ns/odrl/2/trackingParty">
+        <skos:definition xml:lang="en">The Party who is tracking usage.</skos:definition>
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <rdfs:label xml:lang="en">Tracking Party</rdfs:label>
+        <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <skos:scopeNote xml:lang="en">Non-Normative</skos:scopeNote>
+        <rdfs:subPropertyOf rdf:resource="http://www.w3.org/ns/odrl/2/function"/>
+        <skos:note xml:lang="en">May be specified as part of the acceptTracking action.</skos:note>
+      </owl:ObjectProperty>
+    </skos:member>
+    <skos:member>
+      <rdf:Property rdf:about="http://www.w3.org/ns/odrl/2/consentedParty">
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+        <skos:definition xml:lang="en">The Party who obtains the consent.</skos:definition>
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <skos:note xml:lang="en">Maybe specified as part of the obtainConsent action.</skos:note>
+        <rdfs:subPropertyOf rdf:resource="http://www.w3.org/ns/odrl/2/function"/>
+        <skos:scopeNote xml:lang="en">Non-Normative</skos:scopeNote>
+        <rdfs:label xml:lang="en">Consented Party</rdfs:label>
+      </rdf:Property>
+    </skos:member>
+    <skos:member>
+      <owl:ObjectProperty rdf:about="http://www.w3.org/ns/odrl/2/trackedParty">
+        <skos:note xml:lang="en">May be specified as part of the acceptTracking action.</skos:note>
+        <skos:definition xml:lang="en">The Party whose usage is being tracked.</skos:definition>
+        <rdfs:label xml:lang="en">Tracked Party</rdfs:label>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <rdfs:subPropertyOf rdf:resource="http://www.w3.org/ns/odrl/2/function"/>
+        <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+        <skos:scopeNote xml:lang="en">Non-Normative</skos:scopeNote>
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+      </owl:ObjectProperty>
+    </skos:member>
+    <skos:member>
+      <owl:ObjectProperty rdf:about="http://www.w3.org/ns/odrl/2/consentingParty">
+        <rdfs:label xml:lang="en">Consenting Party</rdfs:label>
+        <skos:note xml:lang="en">Maybe specified as part of the obtainConsent action.</skos:note>
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <skos:scopeNote xml:lang="en">Non-Normative</skos:scopeNote>
+        <rdfs:subPropertyOf rdf:resource="http://www.w3.org/ns/odrl/2/function"/>
+        <skos:definition xml:lang="en">The Party to obtain consent from.</skos:definition>
+      </owl:ObjectProperty>
+    </skos:member>
+  </skos:Collection>
+  <skos:Collection rdf:about="http://www.w3.org/ns/odrl/2/#constraintLeftOperandCommon">
+    <skos:member>
+      <odrl:LeftOperand rdf:about="http://www.w3.org/ns/odrl/2/meteredTime">
+        <skos:definition xml:lang="en">An accumulated amount of time period. Right operand value MUST be an xsd:duration as defined by [[xmlschema11-2]].</skos:definition>
+        <skos:note><![CDATA[Example: <code>meteredTime lteq P60M</code> indicates an accumulated period of 60 Minutes or less.]]></skos:note>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+        <skos:note xml:lang="en">Only the eq, lt, lteq operators SHOULD be used.</skos:note>
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <rdfs:label xml:lang="en">Metered Time</rdfs:label>
+        <skos:scopeNote xml:lang="en">Non-Normative</skos:scopeNote>
+      </odrl:LeftOperand>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://www.w3.org/ns/odrl/2/resolution">
+        <rdf:type rdf:resource="http://www.w3.org/ns/odrl/2/LeftOperand"/>
+        <rdfs:label xml:lang="en">Rendition Resolution</rdfs:label>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <skos:note xml:lang="en">Example: the image may be printed at 1200dpi.</skos:note>
+        <skos:scopeNote xml:lang="en">Non-Normative</skos:scopeNote>
+        <skos:definition xml:lang="en">Resolution of the rendition of the Asset.</skos:definition>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://www.w3.org/ns/odrl/2/relativePosition">
+        <rdf:type rdf:resource="http://www.w3.org/ns/odrl/2/LeftOperand"/>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <skos:scopeNote xml:lang="en">Non-Normative</skos:scopeNote>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+        <rdfs:label xml:lang="en">Relative Asset Position</rdfs:label>
+        <skos:definition xml:lang="en">A point in space or time defined with coordinates relative to full measures the positioning of the Asset.</skos:definition>
+        <skos:note xml:lang="en">Example: The upper left corner of a picture may be constrained to a specific position of the canvas rendering it.</skos:note>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <odrl:LeftOperand rdf:about="http://www.w3.org/ns/odrl/2/delayPeriod">
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <skos:scopeNote xml:lang="en">Non-Normative</skos:scopeNote>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+        <skos:definition xml:lang="en">A time delay period. The point in time triggering this period MAY be defined by another temporal Constraint expressed together in a Constraint (utilising the odrl:andSequence operator). Right operand value MUST be an xsd:duration as defined by [[xmlschema11-2]].</skos:definition>
+        <rdfs:label xml:lang="en">Delay Period</rdfs:label>
+        <skos:note xml:lang="en">Only the eq, gt, gteq operators SHOULD be used.</skos:note>
+        <skos:note xml:lang="en"><![CDATA[Example: <code>delayPeriod eq P60M</code> indicates a delay of 60 Minutes before exercising the action.]]></skos:note>
+      </odrl:LeftOperand>
+    </skos:member>
+    <skos:member>
+      <odrl:LeftOperand rdf:about="http://www.w3.org/ns/odrl/2/relativeTemporalPosition">
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <rdfs:label xml:lang="en">Relative Temporal Asset Position</rdfs:label>
+        <skos:scopeNote xml:lang="en">Non-Normative</skos:scopeNote>
+        <skos:definition xml:lang="en">A point in space or time defined with coordinates relative to full measures the positioning of the Asset.</skos:definition>
+        <skos:broaderTransitive rdf:resource="http://www.w3.org/ns/odrl/2/relativePosition"/>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+        <skos:note xml:lang="en">Example: The MP3 music file must be positioned between the positions at 33% and 48% of the temporal length of a stream. Note: See the Left Operand absoluteTemporalAssetPosition. </skos:note>
+      </odrl:LeftOperand>
+    </skos:member>
+    <skos:member>
+      <odrl:LeftOperand rdf:about="http://www.w3.org/ns/odrl/2/spatial">
+        <rdfs:label xml:lang="en">Geospatial Named Area</rdfs:label>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+        <skos:definition xml:lang="en">A named and identified geospatial area with defined borders. An IRI MUST be used to represent this value.</skos:definition>
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <skos:note xml:lang="en">A code value for the area and source of the code must be presented in the Right Operand. For example, the [[iso3166]] Country Codes or the Getty Thesaurus of Geographic Names. </skos:note>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <skos:scopeNote xml:lang="en">Non-Normative</skos:scopeNote>
+      </odrl:LeftOperand>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://www.w3.org/ns/odrl/2/language">
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <skos:scopeNote xml:lang="en">Non-Normative</skos:scopeNote>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+        <rdfs:label xml:lang="en">Language</rdfs:label>
+        <rdf:type rdf:resource="http://www.w3.org/ns/odrl/2/LeftOperand"/>
+        <skos:note xml:lang="en">Example: the asset can only be translated into Greek. Must use [[bcp47]] codes for language values.</skos:note>
+        <skos:definition xml:lang="en">A natural language.</skos:definition>
+      </skos:Concept>
+    </skos:member>
+    <skos:scopeNote xml:lang="en">ODRL Common Vocabulary Terms</skos:scopeNote>
+    <skos:member>
+      <odrl:LeftOperand rdf:about="http://www.w3.org/ns/odrl/2/timeInterval">
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <skos:note xml:lang="en">Only the eq operator SHOULD be used.</skos:note>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+        <skos:definition xml:lang="en">A recurring period of time. Right operand value MUST be an xsd:duration as defined by [[xmlschema11-2]].</skos:definition>
+        <rdfs:label xml:lang="en">Recurring Time Interval</rdfs:label>
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <skos:scopeNote xml:lang="en">Non-Normative</skos:scopeNote>
+        <skos:note><![CDATA[Example: <code>timeInterval eq P7D</code> indicates a recurring 7 day period.]]></skos:note>
+      </odrl:LeftOperand>
+    </skos:member>
+    <skos:member>
+      <owl:NamedIndividual rdf:about="http://www.w3.org/ns/odrl/2/dateTime">
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <skos:definition xml:lang="en">The date (and optional time and timezone) to be compared. Right operand value MUST be an xsd:date or xsd:dateTime as defined by [[xmlschema11-2]].</skos:definition>
+        <rdf:type rdf:resource="http://www.w3.org/ns/odrl/2/LeftOperand"/>
+        <skos:scopeNote xml:lang="en">Non-Normative</skos:scopeNote>
+        <skos:note xml:lang="en">The use of Timezone information is strongly recommended.</skos:note>
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <rdfs:label xml:lang="en">Datetime</rdfs:label>
+        <skos:note xml:lang="en"><![CDATA[The Rule may be exercised before (with operator lt/lteq) or after (with operator gt/gteq) the date(time) defined by the Right operand. Example: <code>dateTime gteq 2017-12-31T06:00Z</code> means the Rule can only be exercised after (and including) 6:00AM on the 31st Decemeber 2017 UTC time.]]></skos:note>
+      </owl:NamedIndividual>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://www.w3.org/ns/odrl/2/count">
+        <rdf:type rdf:resource="http://www.w3.org/ns/odrl/2/LeftOperand"/>
+        <skos:scopeNote xml:lang="en">Non-Normative</skos:scopeNote>
+        <rdfs:label xml:lang="en">Count</rdfs:label>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <skos:definition xml:lang="en">Numeric count.</skos:definition>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <owl:NamedIndividual rdf:about="http://www.w3.org/ns/odrl/2/absoluteSpatialPosition">
+        <rdfs:label xml:lang="en">Absolute Spatial Asset Position</rdfs:label>
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <skos:note xml:lang="en">Example: The upper left corner of a picture may be constrained to a specific position of the canvas rendering it. Note: see also the Left Operand Relative Spatial Asset Position. </skos:note>
+        <skos:definition xml:lang="en">The absolute spatial positions of four corners of a rectangle on a 2D-canvas or the eight corners of a cuboid in a 3D-space for the Asset to fit.</skos:definition>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <rdf:type rdf:resource="http://www.w3.org/ns/odrl/2/LeftOperand"/>
+        <skos:broaderTransitive rdf:resource="http://www.w3.org/ns/odrl/2/absolutePosition"/>
+        <skos:scopeNote xml:lang="en">Non-Normative</skos:scopeNote>
+      </owl:NamedIndividual>
+    </skos:member>
+    <skos:member>
+      <odrl:LeftOperand rdf:about="http://www.w3.org/ns/odrl/2/absoluteTemporalPosition">
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+        <skos:definition xml:lang="en">The absolute temporal positions in a media stream the Asset has to fit.</skos:definition>
+        <skos:scopeNote xml:lang="en">Non-Normative</skos:scopeNote>
+        <skos:broaderTransitive rdf:resource="http://www.w3.org/ns/odrl/2/absolutePosition"/>
+        <rdfs:label xml:lang="en">Absolute Temporal Asset Position</rdfs:label>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <skos:note xml:lang="en">Note: Use with Actions including the Asset in a larger media stream. The fragment part of a Media Fragment URI (https://www.w3.org/TR/media-frags/) may be used for the right operand. See the Left Operand realativeTemporalPosition. Example: The MP3 music file must be positioned between second 192 and 250 of the temporal length of a stream.</skos:note>
+      </odrl:LeftOperand>
+    </skos:member>
+    <skos:member>
+      <odrl:LeftOperand rdf:about="http://www.w3.org/ns/odrl/2/relativeSize">
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+        <rdfs:label xml:lang="en">Relative Asset Size</rdfs:label>
+        <skos:definition xml:lang="en">Measure(s) of one or two axes for 2D-objects or measure(s) of one to tree axes for 3D-objects - expressed as percentages of full values - of the Asset.</skos:definition>
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <skos:note xml:lang="en">Example: The image can be resized in width to a maximum of 200%. Note: See the Left Operand absoluteSize. </skos:note>
+        <skos:scopeNote xml:lang="en">Non-Normative</skos:scopeNote>
+      </odrl:LeftOperand>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://www.w3.org/ns/odrl/2/deliveryChannel">
+        <skos:note xml:lang="en">Example: the asset may be distributed only on mobile networks.</skos:note>
+        <rdfs:label xml:lang="en">Delivery Channel</rdfs:label>
+        <rdf:type rdf:resource="http://www.w3.org/ns/odrl/2/LeftOperand"/>
+        <skos:definition xml:lang="en">The delivery channel used.</skos:definition>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <skos:scopeNote xml:lang="en">Non-Normative</skos:scopeNote>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://www.w3.org/ns/odrl/2/absoluteSize">
+        <skos:note xml:lang="en">Example: The image can be resized in width to a maximum of 1000px.</skos:note>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <rdfs:label xml:lang="en">Absolute Asset Size</rdfs:label>
+        <rdf:type rdf:resource="http://www.w3.org/ns/odrl/2/LeftOperand"/>
+        <skos:definition xml:lang="en">Measure(s) of one or two axes for 2D-objects or measure(s) of one to tree axes for 3D-objects of the Asset.</skos:definition>
+        <skos:scopeNote xml:lang="en">Non-Normative</skos:scopeNote>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <odrl:LeftOperand rdf:about="http://www.w3.org/ns/odrl/2/spatialCoordinates">
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <skos:definition xml:lang="en">A set of coordinates setting the borders of a geospatial area. The coordinates MUST include longitude and latitude, they MAY include altitude and the geodetic datum.</skos:definition>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+        <skos:note xml:lang="en">The default values are the altitude of earth's surface at this location and the WGS 84 datum.</skos:note>
+        <skos:broaderTransitive rdf:resource="http://www.w3.org/ns/odrl/2/spatial"/>
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <skos:scopeNote xml:lang="en">Non-Normative</skos:scopeNote>
+        <rdfs:label xml:lang="en">Geospatial Coordinates</rdfs:label>
+      </odrl:LeftOperand>
+    </skos:member>
+    <skos:member>
+      <odrl:LeftOperand rdf:about="http://www.w3.org/ns/odrl/2/event">
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <skos:scopeNote xml:lang="en">Non-Normative</skos:scopeNote>
+        <skos:definition xml:lang="en">An identified event.</skos:definition>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+        <skos:note xml:lang="en">Events are temporal periods of time, and operators can be used to signal before (lt), during (eq) or after (gt) the event. Example: May be taken during the “FIFA World Cup 2020” only.</skos:note>
+        <rdfs:label xml:lang="en">Event</rdfs:label>
+      </odrl:LeftOperand>
+    </skos:member>
+    <skos:member>
+      <owl:NamedIndividual rdf:about="http://www.w3.org/ns/odrl/2/version">
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <skos:definition xml:lang="en">The range of versions of the Asset.</skos:definition>
+        <skos:note xml:lang="en">Example: Single Paperback or Multiple Issues or version 2.0 or higher.</skos:note>
+        <rdf:type rdf:resource="http://www.w3.org/ns/odrl/2/LeftOperand"/>
+        <rdfs:label xml:lang="en">Version</rdfs:label>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <skos:scopeNote xml:lang="en">Non-Normative</skos:scopeNote>
+      </owl:NamedIndividual>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://www.w3.org/ns/odrl/2/unitOfCount">
+        <rdf:type rdf:resource="http://www.w3.org/ns/odrl/2/LeftOperand"/>
+        <skos:scopeNote xml:lang="en">Non-Normative</skos:scopeNote>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+        <skos:note xml:lang="en">Typically used with Duties to indicate the unit entity to be counted of the Action. Example: A duty to compensate and a unitOfCount constraint of 'perUser' would indicate that the compensation by multiplied by the 'number of users'.</skos:note>
+        <rdfs:label xml:lang="en">Unit Of Count</rdfs:label>
+        <skos:definition xml:lang="en">The unit of measure used for counting.</skos:definition>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <owl:NamedIndividual rdf:about="http://www.w3.org/ns/odrl/2/percentage">
+        <rdfs:label xml:lang="en">Asset Percentage</rdfs:label>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <skos:definition xml:lang="en">A percentage amount. Right operand value MUST be an xsd:decimal from 0 to 100.</skos:definition>
+        <rdf:type rdf:resource="http://www.w3.org/ns/odrl/2/LeftOperand"/>
+        <skos:note xml:lang="en">Example: Extract less than or equal to 50%.</skos:note>
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <skos:scopeNote xml:lang="en">Non-Normative</skos:scopeNote>
+      </owl:NamedIndividual>
+    </skos:member>
+    <skos:member>
+      <owl:NamedIndividual rdf:about="http://www.w3.org/ns/odrl/2/elapsedTime">
+        <skos:definition xml:lang="en">An elapsed time period. Right operand value MUST be an xsd:duration as defined by [[xmlschema11-2]].</skos:definition>
+        <skos:note><![CDATA[Example: <code>elpasedTime eq P60M</code> indicates a total elapsed time of 60 Minutes.]]></skos:note>
+        <rdfs:label xml:lang="en">Elapsed Time</rdfs:label>
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <skos:note xml:lang="en">Only the eq, lt, lteq operators SHOULD be used.</skos:note>
+        <rdf:type rdf:resource="http://www.w3.org/ns/odrl/2/LeftOperand"/>
+        <skos:scopeNote xml:lang="en">Non-Normative</skos:scopeNote>
+      </owl:NamedIndividual>
+    </skos:member>
+    <skos:member>
+      <odrl:LeftOperand rdf:about="http://www.w3.org/ns/odrl/2/purpose">
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <rdfs:label xml:lang="en">Purpose</rdfs:label>
+        <skos:definition xml:lang="en">A defined Purpose.</skos:definition>
+        <skos:scopeNote xml:lang="en">Non-Normative</skos:scopeNote>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+        <skos:note xml:lang="en">Example: Educational use.</skos:note>
+      </odrl:LeftOperand>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://www.w3.org/ns/odrl/2/media">
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <skos:scopeNote xml:lang="en">Non-Normative</skos:scopeNote>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+        <skos:definition xml:lang="en">Category of media context.</skos:definition>
+        <rdfs:label xml:lang="en">Media Context</rdfs:label>
+        <rdf:type rdf:resource="http://www.w3.org/ns/odrl/2/LeftOperand"/>
+        <skos:note xml:lang="en">Example media types: electronic, print, advertising, marketing. Note: The used type should not be an IANA MediaType as they are focused on technical characteristics. </skos:note>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <odrl:LeftOperand rdf:about="http://www.w3.org/ns/odrl/2/recipient">
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <skos:scopeNote xml:lang="en">Non-Normative</skos:scopeNote>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+        <skos:definition xml:lang="en">The party receiving the result/outcome.</skos:definition>
+        <rdfs:label xml:lang="en">Recipient</rdfs:label>
+        <skos:note xml:lang="en">Note: The Right Operand must identify one or more specific Parties or category/ies of the Party.</skos:note>
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+      </odrl:LeftOperand>
+    </skos:member>
+    <skos:member>
+      <odrl:LeftOperand rdf:about="http://www.w3.org/ns/odrl/2/relativeSpatialPosition">
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+        <rdfs:label xml:lang="en">Relative Spatial Asset Position</rdfs:label>
+        <skos:definition xml:lang="en">The relative spatial positions - expressed as percentages of full values - of four corners of a rectangle on a 2D-canvas or the eight corners of a cuboid in a 3D-space of the Asset.</skos:definition>
+        <skos:note xml:lang="en">Note: See the Left Operand absoluteSpatialAssetPosition.</skos:note>
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <skos:scopeNote xml:lang="en">Non-Normative</skos:scopeNote>
+        <skos:broaderTransitive rdf:resource="http://www.w3.org/ns/odrl/2/relativePosition"/>
+      </odrl:LeftOperand>
+    </skos:member>
+    <skos:member>
+      <owl:NamedIndividual rdf:about="http://www.w3.org/ns/odrl/2/product">
+        <skos:note xml:lang="en">Example: May only be used in the XYZ Magazine.</skos:note>
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <rdf:type rdf:resource="http://www.w3.org/ns/odrl/2/LeftOperand"/>
+        <skos:definition xml:lang="en">A Product or service.</skos:definition>
+        <skos:scopeNote xml:lang="en">Non-Normative</skos:scopeNote>
+        <rdfs:label xml:lang="en">Product Context</rdfs:label>
+      </owl:NamedIndividual>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://www.w3.org/ns/odrl/2/virtualLocation">
+        <rdfs:label xml:lang="en">Virtual IT Communication Location</rdfs:label>
+        <skos:note xml:lang="en">Example: an Internet domain or IP address range.</skos:note>
+        <rdf:type rdf:resource="http://www.w3.org/ns/odrl/2/LeftOperand"/>
+        <skos:definition xml:lang="en">An identified location of the IT communication space.</skos:definition>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <skos:scopeNote xml:lang="en">Non-Normative</skos:scopeNote>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <odrl:LeftOperand rdf:about="http://www.w3.org/ns/odrl/2/systemDevice">
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <skos:exactMatch rdf:resource="http://www.w3.org/ns/odrl/2/system"/>
+        <skos:definition xml:lang="en">An identified computing system.</skos:definition>
+        <skos:note xml:lang="en">Example: The system device can be identified by a unique code created from the used hardware.</skos:note>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <skos:scopeNote xml:lang="en">Non-Normative</skos:scopeNote>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+        <skos:exactMatch rdf:resource="http://www.w3.org/ns/odrl/2/device"/>
+        <rdfs:label xml:lang="en">System Device</rdfs:label>
+      </odrl:LeftOperand>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://www.w3.org/ns/odrl/2/fileFormat">
+        <skos:note xml:lang="en">Example: An asset may be transformed into JPEG format.</skos:note>
+        <skos:definition xml:lang="en">A transformed file format.</skos:definition>
+        <rdf:type rdf:resource="http://www.w3.org/ns/odrl/2/LeftOperand"/>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <skos:scopeNote xml:lang="en">Non-Normative</skos:scopeNote>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+        <rdfs:label xml:lang="en">File Format</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <odrl:LeftOperand rdf:about="http://www.w3.org/ns/odrl/2/payAmount">
+        <skos:note xml:lang="en">Note: Can be used for compensation duties with the unit property indicating the currency of the payment.</skos:note>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <rdfs:label xml:lang="en">Payment Amount</rdfs:label>
+        <skos:definition xml:lang="en">The amount of a financial payment. Right operand value MUST be an xsd:decimal. </skos:definition>
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <skos:scopeNote xml:lang="en">Non-Normative</skos:scopeNote>
+      </odrl:LeftOperand>
+    </skos:member>
+    <skos:prefLabel xml:lang="en">Constraint Left Operands</skos:prefLabel>
+    <skos:member>
+      <owl:NamedIndividual rdf:about="http://www.w3.org/ns/odrl/2/industry">
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <skos:definition xml:lang="en">A defined industry sector.</skos:definition>
+        <rdf:type rdf:resource="http://www.w3.org/ns/odrl/2/LeftOperand"/>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <rdfs:label xml:lang="en">Industry Context</rdfs:label>
+        <skos:scopeNote xml:lang="en">Non-Normative</skos:scopeNote>
+        <skos:note xml:lang="en">Example: publishing or financial industry.</skos:note>
+      </owl:NamedIndividual>
+    </skos:member>
+    <skos:member>
+      <odrl:LeftOperand rdf:about="http://www.w3.org/ns/odrl/2/absolutePosition">
+        <skos:note xml:lang="en">Example: The upper left corner of a picture may be constrained to a specific position of the canvas rendering it.</skos:note>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <skos:scopeNote xml:lang="en">Non-Normative</skos:scopeNote>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <skos:definition xml:lang="en">A point in space or time defined with absolute coordinates for the positioning of the Asset.</skos:definition>
+        <rdfs:label xml:lang="en">Absolute Asset Position</rdfs:label>
+      </odrl:LeftOperand>
+    </skos:member>
+  </skos:Collection>
+  <skos:Collection rdf:about="http://www.w3.org/ns/odrl/2/#ruleConcepts">
+    <skos:member>
+      <rdf:Property rdf:about="http://www.w3.org/ns/odrl/2/failure">
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+        <rdfs:range rdf:resource="http://www.w3.org/ns/odrl/2/Rule"/>
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <rdfs:label xml:lang="en">Failure</rdfs:label>
+        <skos:definition xml:lang="en">Failure is an abstract property that defines the violation (or unmet) relationship between Rules.</skos:definition>
+        <skos:note xml:lang="en">The parent property to sub-properties that express explicit failure contexts.</skos:note>
+        <rdfs:domain rdf:resource="http://www.w3.org/ns/odrl/2/Rule"/>
+      </rdf:Property>
+    </skos:member>
+    <skos:prefLabel xml:lang="en">Rule</skos:prefLabel>
+    <skos:member rdf:resource="http://www.w3.org/ns/odrl/2/Rule"/>
+    <skos:scopeNote xml:lang="en">ODRL Core Vocabulary Terms</skos:scopeNote>
+    <skos:member>
+      <rdf:Property rdf:about="http://www.w3.org/ns/odrl/2/relation">
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <skos:definition xml:lang="en">Relation is an abstract property which creates an explicit link between an Action and an Asset.</skos:definition>
+        <skos:note xml:lang="en">Sub-properties of relation are used to define the nature of that link.</skos:note>
+        <rdfs:range rdf:resource="http://www.w3.org/ns/odrl/2/Asset"/>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+        <rdfs:domain>
+          <owl:Class rdf:nodeID="ub1bL678C14">
+            <owl:unionOf rdf:parseType="Collection">
+              <rdf:Description rdf:about="http://www.w3.org/ns/odrl/2/Rule"/>
+              <rdf:Description rdf:about="http://www.w3.org/ns/odrl/2/Policy"/>
+            </owl:unionOf>
+          </owl:Class>
+        </rdfs:domain>
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <rdfs:label xml:lang="en">Relation</rdfs:label>
+      </rdf:Property>
+    </skos:member>
+    <skos:member>
+      <rdf:Property rdf:about="http://www.w3.org/ns/odrl/2/function">
+        <skos:definition xml:lang="en">Function is an abstract property whose sub-properties define the functional roles which may be fulfilled by a party in relation to a Rule.</skos:definition>
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <rdfs:range rdf:resource="http://www.w3.org/ns/odrl/2/Party"/>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <rdfs:domain>
+          <owl:Class rdf:nodeID="ub1bL711C14">
+            <owl:unionOf rdf:parseType="Collection">
+              <rdf:Description rdf:about="http://www.w3.org/ns/odrl/2/Rule"/>
+              <rdf:Description rdf:about="http://www.w3.org/ns/odrl/2/Policy"/>
+            </owl:unionOf>
+          </owl:Class>
+        </rdfs:domain>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+        <rdfs:label xml:lang="en">Function</rdfs:label>
+      </rdf:Property>
+    </skos:member>
+  </skos:Collection>
+  <skos:Collection rdf:about="http://www.w3.org/ns/odrl/2/#deprecatedTerms">
+    <skos:member>
+      <owl:ObjectProperty rdf:about="http://www.w3.org/ns/odrl/2/undefined">
+        <rdfs:label xml:lang="en">Handle Undefined Term</rdfs:label>
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <skos:definition xml:lang="en">Relates the strategy used for handling undefined actions to a Policy.</skos:definition>
+        <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+        <skos:note xml:lang="en">If no strategy is specified, the default is invalid.</skos:note>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <rdfs:range rdf:resource="http://www.w3.org/ns/odrl/2/UndefinedTerm"/>
+      </owl:ObjectProperty>
+    </skos:member>
+    <skos:member rdf:resource="http://www.w3.org/ns/odrl/2/AssetScope"/>
+    <skos:member>
+      <odrl:Action rdf:about="http://www.w3.org/ns/odrl/2/secondaryUse">
+        <skos:definition xml:lang="en">The act of using the asset for a purpose other than the purpose it was intended for.</skos:definition>
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <rdfs:label xml:lang="en">Secondary Use</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+      </odrl:Action>
+    </skos:member>
+    <skos:member rdf:resource="http://www.w3.org/ns/odrl/2/PartyScope"/>
+    <skos:member>
+      <odrl:Action rdf:about="http://www.w3.org/ns/odrl/2/lend">
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+        <rdfs:label xml:lang="en">Lend</rdfs:label>
+        <skos:definition xml:lang="en">The act of making available the asset to a third-party for a fixed period of time without exchange of value.</skos:definition>
+      </odrl:Action>
+    </skos:member>
+    <skos:member>
+      <odrl:Action rdf:about="http://www.w3.org/ns/odrl/2/pay">
+        <skos:definition xml:lang="en">The act of paying a financial amount to a party for use of the asset.</skos:definition>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+        <skos:exactMatch rdf:resource="http://www.w3.org/ns/odrl/2/compensate"/>
+        <rdfs:label xml:lang="en">Pay</rdfs:label>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+      </odrl:Action>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://www.w3.org/ns/odrl/2/write">
+        <skos:definition xml:lang="en">The act of writing to the Asset.</skos:definition>
+        <rdfs:label xml:lang="en">Write</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <skos:exactMatch rdf:resource="http://www.w3.org/ns/odrl/2/modify"/>
+        <rdf:type rdf:resource="http://www.w3.org/ns/odrl/2/Action"/>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <odrl:PartyScope rdf:about="http://www.w3.org/ns/odrl/2/AllConnections">
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <skos:definition xml:lang="en">Specifies that the scope of the relationship is all of the first-level connections of the Party.</skos:definition>
+        <skos:note xml:lang="en">For example, may be used to indicate all “friends” of the Party. Note that “group” scope is also assumed.</skos:note>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+        <skos:scopeNote xml:lang="en">Non-Normative</skos:scopeNote>
+        <rdfs:label xml:lang="en">All First-Level Connections</rdfs:label>
+      </odrl:PartyScope>
+    </skos:member>
+    <skos:member>
+      <owl:NamedIndividual rdf:about="http://www.w3.org/ns/odrl/2/Group">
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <rdfs:label xml:lang="en">Group</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+        <skos:scopeNote xml:lang="en">Non-Normative</skos:scopeNote>
+        <rdf:type rdf:resource="http://www.w3.org/ns/odrl/2/PartyScope"/>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <skos:definition xml:lang="en">Specifies that the scope of the relationship is the defined group with multiple individual members.</skos:definition>
+      </owl:NamedIndividual>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://www.w3.org/ns/odrl/2/inheritAllowed">
+        <skos:note xml:lang="en">A boolean value.</skos:note>
+        <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+        <rdfs:label xml:lang="en">Inheritance Allowed</rdfs:label>
+        <skos:definition xml:lang="en">Indicates if the Policy entity can be inherited.</skos:definition>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#DatatypeProperty"/>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <owl:NamedIndividual rdf:about="http://www.w3.org/ns/odrl/2/ignore">
+        <rdf:type rdf:resource="http://www.w3.org/ns/odrl/2/UndefinedTerm"/>
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <skos:definition xml:lang="en">The Action is to be ignored and is not part of the policy – and the policy remains valid.</skos:definition>
+        <skos:note xml:lang="en">Used to support actions not known to the policy system.</skos:note>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <rdfs:label xml:lang="en">Ignore Undefined Actions</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+      </owl:NamedIndividual>
+    </skos:member>
+    <skos:member>
+      <odrl:Action rdf:about="http://www.w3.org/ns/odrl/2/append">
+        <skos:exactMatch rdf:resource="http://www.w3.org/ns/odrl/2/modify"/>
+        <rdfs:label xml:lang="en">Append</rdfs:label>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+        <skos:definition xml:lang="en">The act of adding to the end of an asset.</skos:definition>
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+      </odrl:Action>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://www.w3.org/ns/odrl/2/proximity">
+        <rdfs:label xml:lang="en">proximity</rdfs:label>
+        <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#DatatypeProperty"/>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+        <skos:note xml:lang="en">This original term and URI from the OMA specification should be used: http://www.openmobilealliance.com/oma-dd/proximity .</skos:note>
+        <skos:definition xml:lang="en">An value indicating the closeness or nearness.</skos:definition>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://www.w3.org/ns/odrl/2/system">
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+        <rdfs:label xml:lang="en">System</rdfs:label>
+        <rdf:type rdf:resource="http://www.w3.org/ns/odrl/2/LeftOperand"/>
+        <skos:definition xml:lang="en">An identified computing system.</skos:definition>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+        <skos:exactMatch rdf:resource="http://www.w3.org/ns/odrl/2/systemDevice"/>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <odrl:Action rdf:about="http://www.w3.org/ns/odrl/2/copy">
+        <skos:exactMatch rdf:resource="http://www.w3.org/ns/odrl/2/reproduce"/>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+        <rdfs:label xml:lang="en">Copy</rdfs:label>
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <skos:definition xml:lang="en">The act of making an exact reproduction of the asset.</skos:definition>
+        <owl:sameAs rdf:resource="http://www.w3.org/ns/odrl/2/reproduce"/>
+      </odrl:Action>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://www.w3.org/ns/odrl/2/preview">
+        <skos:definition xml:lang="en">The act of providing a short preview of the asset.</skos:definition>
+        <skos:note xml:lang="en">Use a time constraint with the appropriate action.</skos:note>
+        <rdfs:label xml:lang="en">Preview</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <rdf:type rdf:resource="http://www.w3.org/ns/odrl/2/Action"/>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <owl:ObjectProperty rdf:about="http://www.w3.org/ns/odrl/2/inheritRelation">
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <skos:definition xml:lang="en">Indentifies the type of inheritance.</skos:definition>
+        <skos:note xml:lang="en">For example, this may indicate the business scenario, such as subscription, or prior arrangements between the parties (that are not machine representable).</skos:note>
+        <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+        <rdfs:label xml:lang="en">Inherit Relation</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+      </owl:ObjectProperty>
+    </skos:member>
+    <skos:member>
+      <odrl:Action rdf:about="http://www.w3.org/ns/odrl/2/shareAlike">
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <skos:definition xml:lang="en">The act of distributing any derivative asset under the same terms as the original asset.</skos:definition>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+        <rdfs:label xml:lang="en">Share-alike</rdfs:label>
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <skos:exactMatch rdf:resource="http://creativecommons.org/ns#ShareAlike"/>
+      </odrl:Action>
+    </skos:member>
+    <skos:member rdf:resource="http://www.w3.org/ns/odrl/2/UndefinedTerm"/>
+    <skos:member>
+      <skos:Concept rdf:about="http://www.w3.org/ns/odrl/2/lease">
+        <skos:definition xml:lang="en">The act of making available the asset to a third-party for a fixed period of time with exchange of value.</skos:definition>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <rdf:type rdf:resource="http://www.w3.org/ns/odrl/2/Action"/>
+        <rdfs:label xml:lang="en">Lease</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://www.w3.org/ns/odrl/2/writeTo">
+        <skos:definition xml:lang="en">The act of adding data to the Asset.</skos:definition>
+        <rdfs:label xml:lang="en">Write to</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.w3.org/ns/odrl/2/modify"/>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <rdf:type rdf:resource="http://www.w3.org/ns/odrl/2/Action"/>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <odrl:Action rdf:about="http://www.w3.org/ns/odrl/2/attachSource">
+        <skos:exactMatch rdf:resource="http://creativecommons.org/ns#SourceCode"/>
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <skos:definition xml:lang="en">The act of attaching the source of the asset and its derivatives.</skos:definition>
+        <rdfs:label xml:lang="en">Attach source</rdfs:label>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+      </odrl:Action>
+    </skos:member>
+    <skos:member>
+      <owl:NamedIndividual rdf:about="http://www.w3.org/ns/odrl/2/AllGroups">
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <rdf:type rdf:resource="http://www.w3.org/ns/odrl/2/PartyScope"/>
+        <rdfs:label xml:lang="en">All Group Connections</rdfs:label>
+        <skos:note xml:lang="en">For example, may be used to indicate all groups that the Party is a member of. Note that “group” scope is also assumed.</skos:note>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <skos:definition xml:lang="en">Specifies that the scope of the relationship is all of the group connections of the Party.</skos:definition>
+        <skos:scopeNote xml:lang="en">Non-Normative</skos:scopeNote>
+      </owl:NamedIndividual>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://www.w3.org/ns/odrl/2/Individual">
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+        <rdf:type rdf:resource="http://www.w3.org/ns/odrl/2/PartyScope"/>
+        <skos:definition xml:lang="en">Specifies that the scope of the relationship is the single Party individual.</skos:definition>
+        <rdfs:label xml:lang="en">Individual</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <odrl:Action rdf:about="http://www.w3.org/ns/odrl/2/extractChar">
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <rdfs:label xml:lang="en">Extract character</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+        <skos:note xml:lang="en">This original term and URI from the ONIX specification should be used: http://www.editeur.org/onix-pl/extract-char .</skos:note>
+        <skos:definition xml:lang="en">The act of extracting (replicating) unchanged characters from the asset.</skos:definition>
+      </odrl:Action>
+    </skos:member>
+    <skos:member>
+      <odrl:Action rdf:about="http://www.w3.org/ns/odrl/2/appendTo">
+        <skos:definition xml:lang="en">The act of appending data to the Asset without modifying the Asset in any other way.</skos:definition>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+        <skos:exactMatch rdf:resource="http://www.w3.org/ns/odrl/2/modify"/>
+        <rdfs:label xml:lang="en">Append To</rdfs:label>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+      </odrl:Action>
+    </skos:member>
+    <skos:member>
+      <owl:NamedIndividual rdf:about="http://www.w3.org/ns/odrl/2/support">
+        <skos:note xml:lang="en">Used to support actions not known to the policy system.</skos:note>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+        <rdfs:label xml:lang="en">Support Undefined Actions</rdfs:label>
+        <skos:definition xml:lang="en">The Action is to be supported as part of the policy – and the policy remains valid.</skos:definition>
+        <rdf:type rdf:resource="http://www.w3.org/ns/odrl/2/UndefinedTerm"/>
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+      </owl:NamedIndividual>
+    </skos:member>
+    <skos:member>
+      <odrl:PartyScope rdf:about="http://www.w3.org/ns/odrl/2/All">
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <rdfs:label xml:lang="en">All</rdfs:label>
+        <skos:definition xml:lang="en">Specifies that the scope of the relationship is all of the collective individuals within a context.</skos:definition>
+        <skos:note xml:lang="en">For example, may be used to indicate all the users of a specific social network the party is a member of. Note that “group” scope is also assumed.</skos:note>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+        <skos:scopeNote xml:lang="en">Non-Normative</skos:scopeNote>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+      </odrl:PartyScope>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://www.w3.org/ns/odrl/2/All2ndConnections">
+        <skos:definition xml:lang="en">Specifies that the scope of the relationship is all of the second-level connections to the Party.</skos:definition>
+        <rdf:type rdf:resource="http://www.w3.org/ns/odrl/2/PartyScope"/>
+        <rdfs:label xml:lang="en">All Second-level Connections</rdfs:label>
+        <skos:note xml:lang="en">For example, may be used to indicate all “friends of friends” of the Party. Note that “group” scope is also assumed.</skos:note>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <skos:scopeNote xml:lang="en">Non-Normative</skos:scopeNote>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://www.w3.org/ns/odrl/2/attachPolicy">
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <skos:definition xml:lang="en">The act of keeping the policy notice with the asset.</skos:definition>
+        <rdf:type rdf:resource="http://www.w3.org/ns/odrl/2/Action"/>
+        <rdfs:label xml:lang="en">Attach policy</rdfs:label>
+        <skos:exactMatch rdf:resource="http://creativecommons.org/ns#Notice"/>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://www.w3.org/ns/odrl/2/commercialize">
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+        <skos:exactMatch rdf:resource="http://creativecommons.org/ns#CommercialUse"/>
+        <rdf:type rdf:resource="http://www.w3.org/ns/odrl/2/Action"/>
+        <rdfs:label xml:lang="en">Commercialize</rdfs:label>
+        <skos:definition xml:lang="en">The act of using the asset in a business environment.</skos:definition>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+      </skos:Concept>
+    </skos:member>
+    <skos:prefLabel xml:lang="en">Deprecated Terms</skos:prefLabel>
+    <skos:member>
+      <odrl:Action rdf:about="http://www.w3.org/ns/odrl/2/export">
+        <skos:definition xml:lang="en">The act of transforming the asset into a new form.</skos:definition>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <rdfs:label xml:lang="en">Export</rdfs:label>
+        <skos:exactMatch rdf:resource="http://www.w3.org/ns/odrl/2/transform"/>
+      </odrl:Action>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://www.w3.org/ns/odrl/2/extractPage">
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <rdf:type rdf:resource="http://www.w3.org/ns/odrl/2/Action"/>
+        <rdfs:label xml:lang="en">Extract page</rdfs:label>
+        <skos:definition xml:lang="en">The act of extracting (replicating) unchanged pages from the asset.</skos:definition>
+        <skos:note xml:lang="en">This original term and URI from the ONIX specification should be used: http://www.editeur.org/onix-pl/extract-page .</skos:note>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://www.w3.org/ns/odrl/2/extractWord">
+        <rdfs:label xml:lang="en">Extract word</rdfs:label>
+        <skos:definition xml:lang="en">The act of extracting (replicating) unchanged words from the asset.</skos:definition>
+        <skos:note xml:lang="en">This original term and URI from the ONIX specification should be used: http://www.editeur.org/onix-pl/extract-word .</skos:note>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <rdf:type rdf:resource="http://www.w3.org/ns/odrl/2/Action"/>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <odrl:Action rdf:about="http://www.w3.org/ns/odrl/2/adHocShare">
+        <rdfs:label xml:lang="en">Ad-hoc sharing</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <skos:definition xml:lang="en">The act of sharing the asset to parties in close proximity to the owner.</skos:definition>
+        <skos:note xml:lang="en">This original term and URI from the OMA specification should be used: http://www.openmobilealliance.com/oma-dd/adhoc-share .</skos:note>
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+      </odrl:Action>
+    </skos:member>
+    <skos:member>
+      <odrl:LeftOperand rdf:about="http://www.w3.org/ns/odrl/2/device">
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+        <rdfs:label xml:lang="en">Device</rdfs:label>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <skos:definition xml:lang="en">An identified computing system.</skos:definition>
+        <skos:exactMatch rdf:resource="http://www.w3.org/ns/odrl/2/systemDevice"/>
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+      </odrl:LeftOperand>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://www.w3.org/ns/odrl/2/timedCount">
+        <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <skos:note xml:lang="en">This original term and URI from the OMA specification should be used: http://www.openmobilealliance.com/oma-dd/timed-count .</skos:note>
+        <rdfs:label xml:lang="en">Timed Count</rdfs:label>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#DatatypeProperty"/>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+        <skos:definition xml:lang="en">The number of seconds after which timed metering use of the asset begins.</skos:definition>
+        <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <rdf:Property rdf:about="http://www.w3.org/ns/odrl/2/scope">
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <skos:definition xml:lang="en">The identifier of a scope that provides context to the extent of the entity.</skos:definition>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <rdfs:label xml:lang="en">Scope</rdfs:label>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+        <skos:note xml:lang="en">Used to define scopes for Assets and Parties.</skos:note>
+      </rdf:Property>
+    </skos:member>
+    <skos:member>
+      <rdf:Property rdf:about="http://www.w3.org/ns/odrl/2/payeeParty">
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+        <skos:definition xml:lang="en">The Party is the recipient of the payment.</skos:definition>
+        <skos:exactMatch rdf:resource="http://www.w3.org/ns/odrl/2/compensatedParty"/>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+        <skos:scopeNote xml:lang="en">Non-Normative</skos:scopeNote>
+        <rdfs:label xml:lang="en">Payee Party</rdfs:label>
+      </rdf:Property>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://www.w3.org/ns/odrl/2/license">
+        <skos:definition xml:lang="en">The act of granting the right to use the asset to a third-party.</skos:definition>
+        <skos:exactMatch rdf:resource="http://www.w3.org/ns/odrl/2/grantUse"/>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <rdfs:label xml:lang="en">License</rdfs:label>
+        <rdf:type rdf:resource="http://www.w3.org/ns/odrl/2/Action"/>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <odrl:Action rdf:about="http://www.w3.org/ns/odrl/2/share">
+        <rdfs:label xml:lang="en">Share</rdfs:label>
+        <skos:exactMatch rdf:resource="http://creativecommons.org/ns#Sharing"/>
+        <skos:definition xml:lang="en">The act of the non-commercial reproduction and distribution of the asset to third-parties.</skos:definition>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+      </odrl:Action>
+    </skos:member>
+  </skos:Collection>
+  <skos:Collection rdf:about="http://www.w3.org/ns/odrl/2/#partyRoles">
+    <skos:member>
+      <skos:Concept rdf:about="http://www.w3.org/ns/odrl/2/assigneeOf">
+        <rdfs:label xml:lang="en">Assignee Of</rdfs:label>
+        <rdfs:domain rdf:resource="http://www.w3.org/ns/odrl/2/Party"/>
+        <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <skos:definition xml:lang="en">Identifies an ODRL Policy for which the identified Party undertakes the assignee functional role.</skos:definition>
+        <rdfs:range rdf:resource="http://www.w3.org/ns/odrl/2/Policy"/>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+        <skos:note xml:lang="en">When assigneeOf has been asserted between a metadata expression and an ODRL Policy, the Party being identified MUST be inferred to undertake the assignee functional role of all the Rules of that Policy.</skos:note>
+      </skos:Concept>
+    </skos:member>
+    <skos:prefLabel xml:lang="en">Party Functions</skos:prefLabel>
+    <skos:member>
+      <owl:ObjectProperty rdf:about="http://www.w3.org/ns/odrl/2/assignee">
+        <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <rdfs:domain>
+          <owl:Class rdf:nodeID="ub1bL1783C14">
+            <owl:unionOf rdf:parseType="Collection">
+              <rdf:Description rdf:about="http://www.w3.org/ns/odrl/2/Rule"/>
+              <rdf:Description rdf:about="http://www.w3.org/ns/odrl/2/Policy"/>
+            </owl:unionOf>
+          </owl:Class>
+        </rdfs:domain>
+        <rdfs:subPropertyOf rdf:resource="http://www.w3.org/ns/odrl/2/function"/>
+        <rdfs:label xml:lang="en">Assignee</rdfs:label>
+        <rdfs:range rdf:resource="http://www.w3.org/ns/odrl/2/Party"/>
+        <skos:definition xml:lang="en">The Party is the recipient of the Rule.</skos:definition>
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+      </owl:ObjectProperty>
+    </skos:member>
+    <skos:scopeNote xml:lang="en">ODRL Core Vocabulary Terms</skos:scopeNote>
+    <skos:member>
+      <rdf:Property rdf:about="http://www.w3.org/ns/odrl/2/assignerOf">
+        <rdfs:domain rdf:resource="http://www.w3.org/ns/odrl/2/Party"/>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+        <skos:definition xml:lang="en">Identifies an ODRL Policy for which the identified Party undertakes the assigner functional role.</skos:definition>
+        <skos:note xml:lang="en">When assignerOf has been asserted between a metadata expression and an ODRL Policy, the Party being identified MUST be inferred to undertake the assigner functional role of all the Rules of that Policy.</skos:note>
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <rdfs:label xml:lang="en">Assigner Of</rdfs:label>
+        <rdfs:range rdf:resource="http://www.w3.org/ns/odrl/2/Policy"/>
+      </rdf:Property>
+    </skos:member>
+    <skos:member>
+      <owl:ObjectProperty rdf:about="http://www.w3.org/ns/odrl/2/assigner">
+        <rdfs:subPropertyOf rdf:resource="http://www.w3.org/ns/odrl/2/function"/>
+        <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <rdfs:range rdf:resource="http://www.w3.org/ns/odrl/2/Party"/>
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <rdfs:domain>
+          <owl:Class rdf:nodeID="ub1bL1795C14">
+            <owl:unionOf rdf:parseType="Collection">
+              <rdf:Description rdf:about="http://www.w3.org/ns/odrl/2/Rule"/>
+              <rdf:Description rdf:about="http://www.w3.org/ns/odrl/2/Policy"/>
+            </owl:unionOf>
+          </owl:Class>
+        </rdfs:domain>
+        <rdfs:label xml:lang="en">Assigner</rdfs:label>
+        <skos:definition xml:lang="en">The Party is the issuer of the Rule.</skos:definition>
+      </owl:ObjectProperty>
+    </skos:member>
+  </skos:Collection>
+  <skos:Collection rdf:about="http://www.w3.org/ns/odrl/2/#prohibitions">
+    <skos:prefLabel xml:lang="en">Prohibition</skos:prefLabel>
+    <skos:member>
+      <rdf:Property rdf:about="http://www.w3.org/ns/odrl/2/prohibition">
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <rdfs:range rdf:resource="http://www.w3.org/ns/odrl/2/Prohibition"/>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+        <rdfs:label xml:lang="en">Has Prohibition</rdfs:label>
+        <rdfs:domain rdf:resource="http://www.w3.org/ns/odrl/2/Policy"/>
+        <skos:definition xml:lang="en">Relates an individual Prohibition to a Policy.</skos:definition>
+      </rdf:Property>
+    </skos:member>
+    <skos:scopeNote xml:lang="en">ODRL Core Vocabulary Terms</skos:scopeNote>
+    <skos:member rdf:resource="http://www.w3.org/ns/odrl/2/Prohibition"/>
+  </skos:Collection>
+  <skos:Collection rdf:about="http://www.w3.org/ns/odrl/2/#policyConcepts">
+    <skos:member>
+      <skos:Concept rdf:about="http://www.w3.org/ns/odrl/2/uid">
+        <skos:definition xml:lang="en">An unambiguous identifier</skos:definition>
+        <skos:note xml:lang="en">Used by the Policy, Rule, Asset, and Party Classes.</skos:note>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <rdfs:label xml:lang="en">Unique Identifier</rdfs:label>
+        <rdfs:domain>
+          <owl:Class rdf:nodeID="ub1bL457C14">
+            <owl:unionOf rdf:parseType="Collection">
+              <rdf:Description rdf:about="http://www.w3.org/ns/odrl/2/Policy"/>
+              <rdf:Description rdf:about="http://www.w3.org/ns/odrl/2/Asset"/>
+              <rdf:Description rdf:about="http://www.w3.org/ns/odrl/2/Rule"/>
+              <rdf:Description rdf:about="http://www.w3.org/ns/odrl/2/Party"/>
+            </owl:unionOf>
+          </owl:Class>
+        </rdfs:domain>
+        <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+      </skos:Concept>
+    </skos:member>
+    <skos:member rdf:resource="http://www.w3.org/ns/odrl/2/Policy"/>
+    <skos:member>
+      <skos:Concept rdf:about="http://www.w3.org/ns/odrl/2/profile">
+        <skos:definition xml:lang="en">The identifier(s) of an ODRL Profile that the Policy conforms to.</skos:definition>
+        <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+        <rdfs:label xml:lang="en">Profile</rdfs:label>
+        <rdfs:domain rdf:resource="http://www.w3.org/ns/odrl/2/Policy"/>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <skos:note xml:lang="en">The profile property is mandatory if the Policy is using an ODRL Profile.</skos:note>
+      </skos:Concept>
+    </skos:member>
+    <skos:prefLabel xml:lang="en">Policy</skos:prefLabel>
+    <skos:member>
+      <skos:Concept rdf:about="http://www.w3.org/ns/odrl/2/inheritFrom">
+        <rdfs:domain rdf:resource="http://www.w3.org/ns/odrl/2/Policy"/>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+        <rdfs:label xml:lang="en">Inherits From</rdfs:label>
+        <skos:note xml:lang="en">The child policy will inherit Rules from the parent policy</skos:note>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <skos:definition xml:lang="en">Relates a (child) policy to another (parent) policy from which terms are inherited.</skos:definition>
+        <rdfs:range rdf:resource="http://www.w3.org/ns/odrl/2/Policy"/>
+        <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+      </skos:Concept>
+    </skos:member>
+    <skos:scopeNote xml:lang="en">ODRL Core Vocabulary Terms</skos:scopeNote>
+  </skos:Collection>
+  <skos:Collection rdf:about="http://www.w3.org/ns/odrl/2/#constraintRightOpCommon">
+    <skos:member>
+      <owl:NamedIndividual rdf:about="http://www.w3.org/ns/odrl/2/policyUsage">
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <skos:note xml:lang="en"><![CDATA[This can be used to express constraints related to the time the policy is exercised. For example,  <code>event lt policyUsage</code> expresses a constraint on the Action to occur before the policy is exercised. Other operators may be used to indicate during (eg) or after (gt, gte) policy usage.]]></skos:note>
+        <skos:definition xml:lang="en">Indicates the time when the policy is exercised.</skos:definition>
+        <rdf:type rdf:resource="http://www.w3.org/ns/odrl/2/RightOperand"/>
+        <rdfs:label xml:lang="en">Policy Usage Time</rdfs:label>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <skos:scopeNote xml:lang="en">Non-Normative</skos:scopeNote>
+      </owl:NamedIndividual>
+    </skos:member>
+    <skos:prefLabel xml:lang="en">Constraint Right Operands</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">ODRL Common Vocabulary Terms</skos:scopeNote>
+  </skos:Collection>
+  <skos:Collection rdf:about="http://www.w3.org/ns/odrl/2/#constraints">
+    <skos:member rdf:resource="http://www.w3.org/ns/odrl/2/Constraint"/>
+    <skos:member rdf:resource="http://www.w3.org/ns/odrl/2/Operator"/>
+    <skos:member>
+      <rdf:Property rdf:about="http://www.w3.org/ns/odrl/2/leftOperand">
+        <rdfs:label xml:lang="en">Has Left Operand</rdfs:label>
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <rdfs:range rdf:resource="http://www.w3.org/ns/odrl/2/LeftOperand"/>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <rdfs:domain rdf:resource="http://www.w3.org/ns/odrl/2/Constraint"/>
+        <skos:definition xml:lang="en">The left operand in a constraint expression.</skos:definition>
+      </rdf:Property>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://www.w3.org/ns/odrl/2/rightOperand">
+        <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+        <skos:note xml:lang="en">When used with set-based operators, a list of values may be used.</skos:note>
+        <rdfs:range>
+          <owl:Class rdf:nodeID="ub1bL843C13">
+            <owl:unionOf rdf:parseType="Collection">
+              <rdf:Description rdf:about="http://www.w3.org/ns/odrl/2/RightOperand"/>
+              <rdf:Description rdf:about="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+              <rdf:Description rdf:about="http://www.w3.org/2001/XMLSchema#anyURI"/>
+            </owl:unionOf>
+          </owl:Class>
+        </rdfs:range>
+        <rdfs:domain rdf:resource="http://www.w3.org/ns/odrl/2/Constraint"/>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#DataTypeProperty"/>
+        <skos:definition xml:lang="en">The value of the right operand in a constraint expression.</skos:definition>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <rdfs:label xml:lang="en">Has Right Operand</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member rdf:resource="http://www.w3.org/ns/odrl/2/LeftOperand"/>
+    <skos:member rdf:resource="http://www.w3.org/ns/odrl/2/RightOperand"/>
+    <skos:member>
+      <rdf:Property rdf:about="http://www.w3.org/ns/odrl/2/rightOperandReference">
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <rdfs:domain rdf:resource="http://www.w3.org/ns/odrl/2/Constraint"/>
+        <skos:note xml:lang="en">An IRI that MUST be dereferenced to obtain the actual right operand value. When used with set-based operators, a list of IRIs may be used</skos:note>
+        <rdfs:label xml:lang="en">Has Right Operand Reference</rdfs:label>
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <skos:definition xml:lang="en">A reference to a web resource providing the value for the right operand of a Constraint.</skos:definition>
+      </rdf:Property>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://www.w3.org/ns/odrl/2/dataType">
+        <skos:note xml:lang="en">In RDF encodings, use of the rdf:datatype MUST be used. In JSON-LD encoding, the use of @type MUST be used.</skos:note>
+        <skos:definition xml:lang="en">The datatype of the value of the rightOperand or rightOperandReference of a Constraint.</skos:definition>
+        <rdfs:domain rdf:resource="http://www.w3.org/ns/odrl/2/Constraint"/>
+        <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Datatype"/>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <rdfs:label xml:lang="en">Datatype</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <rdf:Property rdf:about="http://www.w3.org/ns/odrl/2/constraint">
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <rdfs:domain>
+          <owl:Class rdf:nodeID="ub1bL742C14">
+            <owl:unionOf rdf:parseType="Collection">
+              <rdf:Description rdf:about="http://www.w3.org/ns/odrl/2/Policy"/>
+              <rdf:Description rdf:about="http://www.w3.org/ns/odrl/2/Rule"/>
+            </owl:unionOf>
+          </owl:Class>
+        </rdfs:domain>
+        <skos:definition xml:lang="en">Constraint applied to a Rule</skos:definition>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+        <rdfs:range>
+          <owl:Class rdf:nodeID="ub1bL746C13">
+            <owl:unionOf rdf:parseType="Collection">
+              <rdf:Description rdf:about="http://www.w3.org/ns/odrl/2/Constraint"/>
+              <rdf:Description rdf:about="http://www.w3.org/ns/odrl/2/LogicalConstraint"/>
+            </owl:unionOf>
+          </owl:Class>
+        </rdfs:range>
+        <rdfs:label xml:lang="en">Has Constraint</rdfs:label>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <skos:note xml:lang="en">Constraints on Rules are used to determine if a rule is Active or not. Example: the Permission rule is only active during the year 2018.</skos:note>
+      </rdf:Property>
+    </skos:member>
+    <skos:member>
+      <rdf:Property rdf:about="http://www.w3.org/ns/odrl/2/operator">
+        <rdfs:label xml:lang="en">Has Operator</rdfs:label>
+        <rdfs:range rdf:resource="http://www.w3.org/ns/odrl/2/Operator"/>
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <skos:definition xml:lang="en">The operator function applied to operands of a Constraint</skos:definition>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+        <rdfs:domain rdf:resource="http://www.w3.org/ns/odrl/2/Constraint"/>
+      </rdf:Property>
+    </skos:member>
+    <skos:member>
+      <rdf:Property rdf:about="http://www.w3.org/ns/odrl/2/status">
+        <rdfs:domain rdf:resource="http://www.w3.org/ns/odrl/2/Constraint"/>
+        <skos:definition xml:lang="en">the value generated from the leftOperand action or a value related to the leftOperand set as the reference for the comparison.</skos:definition>
+        <rdfs:label xml:lang="en">Status</rdfs:label>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+      </rdf:Property>
+    </skos:member>
+    <skos:prefLabel xml:lang="en">Constraint</skos:prefLabel>
+    <skos:member>
+      <rdf:Property rdf:about="http://www.w3.org/ns/odrl/2/unit">
+        <skos:definition xml:lang="en">The unit of measurement of the value of the rightOperand or rightOperandReference of a Constraint.</skos:definition>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <rdfs:label xml:lang="en">Unit</rdfs:label>
+        <rdfs:domain rdf:resource="http://www.w3.org/ns/odrl/2/Constraint"/>
+      </rdf:Property>
+    </skos:member>
+    <skos:member>
+      <rdf:Property rdf:about="http://www.w3.org/ns/odrl/2/refinement">
+        <skos:definition xml:lang="en">Constraint used to refine the semantics of an Action, or Party/Asset Collection</skos:definition>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+        <rdfs:domain>
+          <owl:Class rdf:nodeID="ub1bL757C14">
+            <owl:unionOf rdf:parseType="Collection">
+              <rdf:Description rdf:about="http://www.w3.org/ns/odrl/2/Action"/>
+              <rdf:Description rdf:about="http://www.w3.org/ns/odrl/2/AssetCollection"/>
+              <rdf:Description rdf:about="http://www.w3.org/ns/odrl/2/PartyCollection"/>
+            </owl:unionOf>
+          </owl:Class>
+        </rdfs:domain>
+        <rdfs:label xml:lang="en">Refinement</rdfs:label>
+        <rdfs:range>
+          <owl:Class rdf:nodeID="ub1bL761C13">
+            <owl:unionOf rdf:parseType="Collection">
+              <rdf:Description rdf:about="http://www.w3.org/ns/odrl/2/Constraint"/>
+              <rdf:Description rdf:about="http://www.w3.org/ns/odrl/2/LogicalConstraint"/>
+            </owl:unionOf>
+          </owl:Class>
+        </rdfs:range>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <skos:note xml:lang="en">Example: the Action print is only permitted on 50% of the asset.</skos:note>
+      </rdf:Property>
+    </skos:member>
+    <skos:scopeNote xml:lang="en">ODRL Core Vocabulary Terms</skos:scopeNote>
+  </skos:Collection>
+  <skos:Collection rdf:about="http://www.w3.org/ns/odrl/2/#assetRelationsCommon">
+    <skos:prefLabel xml:lang="en">Asset Relations</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">ODRL Common Vocabulary Terms</skos:scopeNote>
+    <skos:member>
+      <rdf:Property rdf:about="http://www.w3.org/ns/odrl/2/output">
+        <rdfs:range rdf:resource="http://www.w3.org/ns/odrl/2/Asset"/>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+        <rdfs:label xml:lang="en">Output</rdfs:label>
+        <rdfs:subPropertyOf rdf:resource="http://www.w3.org/ns/odrl/2/relation"/>
+        <rdfs:domain rdf:resource="http://www.w3.org/ns/odrl/2/Rule"/>
+        <skos:definition xml:lang="en">The output property specifies the Asset which is created from the output of the Action.</skos:definition>
+        <skos:scopeNote xml:lang="en">Non-Normative</skos:scopeNote>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+      </rdf:Property>
+    </skos:member>
+  </skos:Collection>
+  <skos:Collection rdf:about="http://www.w3.org/ns/odrl/2/#assetRelations">
+    <skos:prefLabel xml:lang="en">Asset Relations</skos:prefLabel>
+    <skos:member>
+      <owl:ObjectProperty rdf:about="http://www.w3.org/ns/odrl/2/target">
+        <rdfs:label xml:lang="en">Target</rdfs:label>
+        <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <rdfs:domain>
+          <owl:Class rdf:nodeID="ub1bL700C14">
+            <owl:unionOf rdf:parseType="Collection">
+              <rdf:Description rdf:about="http://www.w3.org/ns/odrl/2/Rule"/>
+              <rdf:Description rdf:about="http://www.w3.org/ns/odrl/2/Policy"/>
+            </owl:unionOf>
+          </owl:Class>
+        </rdfs:domain>
+        <rdfs:subPropertyOf rdf:resource="http://www.w3.org/ns/odrl/2/relation"/>
+        <rdfs:range rdf:resource="http://www.w3.org/ns/odrl/2/Asset"/>
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <skos:definition xml:lang="en">The target property indicates the Asset that is the primary subject to which the Rule action directly applies.</skos:definition>
+      </owl:ObjectProperty>
+    </skos:member>
+    <skos:member>
+      <rdf:Property rdf:about="http://www.w3.org/ns/odrl/2/hasPolicy">
+        <skos:definition xml:lang="en">Identifies an ODRL Policy for which the identified Asset is the target Asset to all the Rules.</skos:definition>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+        <rdfs:range rdf:resource="http://www.w3.org/ns/odrl/2/Policy"/>
+        <rdfs:label xml:lang="en">Target Policy</rdfs:label>
+        <skos:note xml:lang="en">The Asset being identified MUST be inferred to be the target Asset of all of the Rules of the Policy.</skos:note>
+        <rdfs:domain rdf:resource="http://www.w3.org/ns/odrl/2/Asset"/>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+      </rdf:Property>
+    </skos:member>
+    <skos:scopeNote xml:lang="en">ODRL Core Vocabulary Terms</skos:scopeNote>
+  </skos:Collection>
+  <skos:Collection rdf:about="http://www.w3.org/ns/odrl/2/#constraintLogicalOperands">
+    <skos:member>
+      <skos:Concept rdf:about="http://www.w3.org/ns/odrl/2/andSequence">
+        <skos:definition xml:lang="en">The relation is satisfied when each of the Constraints are satisfied in the order specified.</skos:definition>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+        <skos:note xml:lang="en">This property MUST only be used for Logical Constraints, and the list of operand values MUST be Constraint instances. The order of the list MUST be preserved. The andSequence operator is an example where there may be temporal conditional requirements between the operands. This may lead to situations where the outcome is unresolvable, such as deadlock if one of the Constraints is unable to be satisfied. ODRL Processing systems SHOULD plan for these scenarios and implement mechanisms to resolve them.</skos:note>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <rdfs:label xml:lang="en">And Sequence</rdfs:label>
+        <rdfs:subPropertyOf rdf:resource="http://www.w3.org/ns/odrl/2/operand"/>
+        <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://www.w3.org/ns/odrl/2/or">
+        <rdfs:label xml:lang="en">Or</rdfs:label>
+        <rdfs:subPropertyOf rdf:resource="http://www.w3.org/ns/odrl/2/operand"/>
+        <skos:definition xml:lang="en">The relation is satisfied when at least one of the Constraints is satisfied.</skos:definition>
+        <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+        <skos:note xml:lang="en">This property MUST only be used for Logical Constraints, and the list of operand values MUST be Constraint instances.</skos:note>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <rdf:Property rdf:about="http://www.w3.org/ns/odrl/2/xone">
+        <skos:note xml:lang="en">This property MUST only be used for Logical Constraints, and the list of operand values MUST be Constraint instances.</skos:note>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <rdfs:label xml:lang="en">Only One</rdfs:label>
+        <rdfs:subPropertyOf rdf:resource="http://www.w3.org/ns/odrl/2/operand"/>
+        <skos:definition xml:lang="en">The relation is satisfied when only one, and not more, of the Constaints is satisfied</skos:definition>
+      </rdf:Property>
+    </skos:member>
+    <skos:prefLabel xml:lang="en">Logical Constraint Operands</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">ODRL Core Vocabulary Terms</skos:scopeNote>
+    <skos:member>
+      <rdf:Property rdf:about="http://www.w3.org/ns/odrl/2/and">
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+        <rdfs:label xml:lang="en">And</rdfs:label>
+        <skos:definition xml:lang="en">The relation is satisfied when all of the Constraints are satisfied.</skos:definition>
+        <rdfs:subPropertyOf rdf:resource="http://www.w3.org/ns/odrl/2/operand"/>
+        <skos:note xml:lang="en">This property MUST only be used for Logical Constraints, and the list of operand values MUST be Constraint instances.</skos:note>
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+      </rdf:Property>
+    </skos:member>
+  </skos:Collection>
+  <skos:Collection rdf:about="http://www.w3.org/ns/odrl/2/#duties">
+    <skos:member>
+      <skos:Concept rdf:about="http://www.w3.org/ns/odrl/2/obligation">
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+        <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+        <skos:definition xml:lang="en">Relates an individual Duty to a Policy.</skos:definition>
+        <skos:note xml:lang="en">The Duty is a requirement which must be fulfilled.</skos:note>
+        <rdfs:domain rdf:resource="http://www.w3.org/ns/odrl/2/Policy"/>
+        <rdfs:label xml:lang="en">Obligation</rdfs:label>
+        <rdfs:range rdf:resource="http://www.w3.org/ns/odrl/2/Duty"/>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+      </skos:Concept>
+    </skos:member>
+    <skos:member rdf:resource="http://www.w3.org/ns/odrl/2/Duty"/>
+    <skos:scopeNote xml:lang="en">ODRL Core Vocabulary Terms</skos:scopeNote>
+    <skos:member>
+      <rdf:Property rdf:about="http://www.w3.org/ns/odrl/2/consequence">
+        <rdfs:subPropertyOf rdf:resource="http://www.w3.org/ns/odrl/2/failure"/>
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <skos:note xml:lang="en">The consequence property is utilised to express the repercussions of not fulfilling an agreed obligation (for a Policy) or duty (for a Permission).</skos:note>
+        <rdfs:domain rdf:resource="http://www.w3.org/ns/odrl/2/Duty"/>
+        <skos:definition xml:lang="en">Relates a Duty to another Duty, the latter being a consequence of not fulfilling the former.</skos:definition>
+        <rdfs:range rdf:resource="http://www.w3.org/ns/odrl/2/Duty"/>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <rdfs:label xml:lang="en">Consequence</rdfs:label>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+      </rdf:Property>
+    </skos:member>
+    <skos:member>
+      <rdf:Property rdf:about="http://www.w3.org/ns/odrl/2/remedy">
+        <rdfs:label xml:lang="en">Remedy</rdfs:label>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+        <skos:note xml:lang="en">The remedy property expresses an agreed Duty that must be fulfilled in case that a Prohibition has been violated by being exercised.</skos:note>
+        <rdfs:subPropertyOf rdf:resource="http://www.w3.org/ns/odrl/2/failure"/>
+        <skos:definition xml:lang="en">Relates an individual remedy Duty to a Prohibition.</skos:definition>
+        <rdfs:range rdf:resource="http://www.w3.org/ns/odrl/2/Duty"/>
+        <rdfs:domain rdf:resource="http://www.w3.org/ns/odrl/2/Prohibition"/>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+      </rdf:Property>
+    </skos:member>
+    <skos:member>
+      <rdf:Property rdf:about="http://www.w3.org/ns/odrl/2/duty">
+        <skos:definition xml:lang="en">Relates an individual Duty to a Permission.</skos:definition>
+        <rdfs:domain rdf:resource="http://www.w3.org/ns/odrl/2/Permission"/>
+        <skos:note xml:lang="en">A Duty is a pre-condition which must be fulfilled in order to receive the Permission.</skos:note>
+        <rdfs:range rdf:resource="http://www.w3.org/ns/odrl/2/Duty"/>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <rdfs:label xml:lang="en">Has Duty</rdfs:label>
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+      </rdf:Property>
+    </skos:member>
+    <skos:prefLabel xml:lang="en">Duty</skos:prefLabel>
+  </skos:Collection>
+  <skos:Collection rdf:about="http://www.w3.org/ns/odrl/2/#partyConcepts">
+    <skos:member>
+      <rdf:Property rdf:about="http://www.w3.org/ns/odrl/2/source">
+        <rdfs:domain>
+          <owl:Class rdf:nodeID="ub1bL468C14">
+            <owl:unionOf rdf:parseType="Collection">
+              <rdf:Description rdf:about="http://www.w3.org/ns/odrl/2/AssetCollection"/>
+              <rdf:Description rdf:about="http://www.w3.org/ns/odrl/2/PartyCollection"/>
+            </owl:unionOf>
+          </owl:Class>
+        </rdfs:domain>
+        <skos:definition xml:lang="en">Reference to a Asset/PartyCollection</skos:definition>
+        <rdfs:label xml:lang="en">Source</rdfs:label>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <skos:note xml:lang="en">Used by AssetCollection and PartyCollection when constraints are applied.</skos:note>
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+      </rdf:Property>
+    </skos:member>
+    <skos:prefLabel xml:lang="en">Party</skos:prefLabel>
+    <skos:member>
+      <rdf:Property rdf:about="http://www.w3.org/ns/odrl/2/partOf">
+        <skos:definition xml:lang="en">Identifies an Asset/PartyCollection that the Asset/Party is a member of.</skos:definition>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+        <rdfs:label xml:lang="en">Part Of</rdfs:label>
+        <rdfs:domain>
+          <owl:Class rdf:nodeID="ub1bL403C14">
+            <owl:unionOf rdf:parseType="Collection">
+              <rdf:Description rdf:about="http://www.w3.org/ns/odrl/2/Asset"/>
+              <rdf:Description rdf:about="http://www.w3.org/ns/odrl/2/Party"/>
+            </owl:unionOf>
+          </owl:Class>
+        </rdfs:domain>
+        <rdfs:range>
+          <owl:Class rdf:nodeID="ub1bL407C13">
+            <owl:unionOf rdf:parseType="Collection">
+              <rdf:Description rdf:about="http://www.w3.org/ns/odrl/2/AssetCollection"/>
+              <rdf:Description rdf:about="http://www.w3.org/ns/odrl/2/PartyCollection"/>
+            </owl:unionOf>
+          </owl:Class>
+        </rdfs:range>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+      </rdf:Property>
+    </skos:member>
+    <skos:member rdf:resource="http://www.w3.org/ns/odrl/2/Party"/>
+    <skos:member rdf:resource="http://www.w3.org/ns/odrl/2/PartyCollection"/>
+    <skos:scopeNote xml:lang="en">ODRL Core Vocabulary Terms</skos:scopeNote>
+  </skos:Collection>
+  <skos:Collection rdf:about="http://www.w3.org/ns/odrl/2/#conflictConcepts">
+    <skos:member>
+      <skos:Concept rdf:about="http://www.w3.org/ns/odrl/2/perm">
+        <skos:note xml:lang="en">Used to determine policy conflict outcomes.</skos:note>
+        <skos:definition xml:lang="en">Permissions take preference over prohibitions.</skos:definition>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+        <rdfs:label xml:lang="en">Prefer Permissions</rdfs:label>
+        <rdf:type rdf:resource="http://www.w3.org/ns/odrl/2/ConflictTerm"/>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <odrl:ConflictTerm rdf:about="http://www.w3.org/ns/odrl/2/prohibit">
+        <skos:note xml:lang="en">Used to determine policy conflict outcomes.</skos:note>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <rdfs:label xml:lang="en">Prefer Prohibitions</rdfs:label>
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <skos:definition xml:lang="en">Prohibitions take preference over permissions.</skos:definition>
+      </odrl:ConflictTerm>
+    </skos:member>
+    <skos:scopeNote xml:lang="en">ODRL Core Vocabulary Terms</skos:scopeNote>
+    <skos:member>
+      <skos:Concept rdf:about="http://www.w3.org/ns/odrl/2/conflict">
+        <rdfs:label xml:lang="en">Handle Policy Conflicts</rdfs:label>
+        <rdfs:domain rdf:resource="http://www.w3.org/ns/odrl/2/Policy"/>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <skos:note xml:lang="en">If no strategy is specified, the default is invalid.</skos:note>
+        <rdfs:range rdf:resource="http://www.w3.org/ns/odrl/2/ConflictTerm"/>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+        <skos:definition xml:lang="en">The conflict-resolution strategy for a Policy.</skos:definition>
+        <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://www.w3.org/ns/odrl/2/invalid">
+        <rdf:type rdf:resource="http://www.w3.org/ns/odrl/2/ConflictTerm"/>
+        <skos:definition xml:lang="en">The policy is void.</skos:definition>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <skos:scopeNote xml:lang="en">Non-Normative</skos:scopeNote>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+        <skos:note xml:lang="en">Used to indicate the policy is void for Conflict Strategy.</skos:note>
+        <rdfs:label xml:lang="en">Void Policy</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member rdf:resource="http://www.w3.org/ns/odrl/2/ConflictTerm"/>
+    <skos:prefLabel xml:lang="en">Policy Conflict Strategy</skos:prefLabel>
+  </skos:Collection>
+  <skos:Collection rdf:about="http://www.w3.org/ns/odrl/2/#constraintRelationalOperators">
+    <skos:member>
+      <skos:Concept rdf:about="http://www.w3.org/ns/odrl/2/lteq">
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <rdfs:label xml:lang="en">Less than or equal to</rdfs:label>
+        <skos:definition xml:lang="en">Indicating that a given value is less than or equal to the right operand of the Constraint.</skos:definition>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+        <rdf:type rdf:resource="http://www.w3.org/ns/odrl/2/Operator"/>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <odrl:Operator rdf:about="http://www.w3.org/ns/odrl/2/isPartOf">
+        <skos:definition xml:lang="en">A set-based operator indicating that a given value is contained by the right operand of the Constraint.</skos:definition>
+        <rdfs:label xml:lang="en">Is part of</rdfs:label>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+      </odrl:Operator>
+    </skos:member>
+    <skos:member>
+      <odrl:Operator rdf:about="http://www.w3.org/ns/odrl/2/eq">
+        <rdfs:label xml:lang="en">Equal to</rdfs:label>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+        <skos:definition xml:lang="en">Indicating that a given value equals the right operand of the Constraint.</skos:definition>
+      </odrl:Operator>
+    </skos:member>
+    <skos:member>
+      <owl:NamedIndividual rdf:about="http://www.w3.org/ns/odrl/2/neq">
+        <skos:definition xml:lang="en">Indicating that a given value is not equal to the right operand of the Constraint.</skos:definition>
+        <rdf:type rdf:resource="http://www.w3.org/ns/odrl/2/Operator"/>
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <rdfs:label xml:lang="en">Not equal to</rdfs:label>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+      </owl:NamedIndividual>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://www.w3.org/ns/odrl/2/isA">
+        <skos:definition xml:lang="en">A set-based operator indicating that a given value is an instance of the right operand of the Constraint.</skos:definition>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <rdfs:label xml:lang="en">Is a</rdfs:label>
+        <rdf:type rdf:resource="http://www.w3.org/ns/odrl/2/Operator"/>
+      </skos:Concept>
+    </skos:member>
+    <skos:scopeNote xml:lang="en">ODRL Core Vocabulary Terms</skos:scopeNote>
+    <skos:member>
+      <odrl:Operator rdf:about="http://www.w3.org/ns/odrl/2/gteq">
+        <rdfs:label xml:lang="en">Greater than or equal to</rdfs:label>
+        <skos:definition xml:lang="en">Indicating that a given value is greater than or equal to the right operand of the Constraint.</skos:definition>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+      </odrl:Operator>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://www.w3.org/ns/odrl/2/hasPart">
+        <rdf:type rdf:resource="http://www.w3.org/ns/odrl/2/Operator"/>
+        <rdfs:label xml:lang="en">Has part</rdfs:label>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <skos:definition xml:lang="en">A set-based operator indicating that a given value contains the right operand of the Constraint.</skos:definition>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://www.w3.org/ns/odrl/2/lt">
+        <rdfs:label xml:lang="en">Less than</rdfs:label>
+        <rdf:type rdf:resource="http://www.w3.org/ns/odrl/2/Operator"/>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+        <skos:definition xml:lang="en">Indicating that a given value is less than the right operand of the Constraint.</skos:definition>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://www.w3.org/ns/odrl/2/gt">
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+        <rdf:type rdf:resource="http://www.w3.org/ns/odrl/2/Operator"/>
+        <rdfs:label xml:lang="en">Greater than</rdfs:label>
+        <skos:definition xml:lang="en">Indicating that a given value is greater than the right operand of the Constraint.</skos:definition>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://www.w3.org/ns/odrl/2/isAllOf">
+        <skos:definition xml:lang="en">A set-based operator indicating that a given value is all of the right operand of the Constraint.</skos:definition>
+        <rdf:type rdf:resource="http://www.w3.org/ns/odrl/2/Operator"/>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+        <rdfs:label xml:lang="en">Is all of</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <odrl:Operator rdf:about="http://www.w3.org/ns/odrl/2/isAnyOf">
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+        <rdfs:label xml:lang="en">Is any of</rdfs:label>
+        <skos:definition xml:lang="en">A set-based operator indicating that a given value is any of the right operand of the Constraint.</skos:definition>
+      </odrl:Operator>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://www.w3.org/ns/odrl/2/isNoneOf">
+        <skos:definition xml:lang="en">A set-based operator indicating that a given value is none of the right operand of the Constraint.</skos:definition>
+        <rdfs:label xml:lang="en">Is none of</rdfs:label>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+        <rdf:type rdf:resource="http://www.w3.org/ns/odrl/2/Operator"/>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+      </skos:Concept>
+    </skos:member>
+    <skos:prefLabel xml:lang="en">Constraint Operators</skos:prefLabel>
+  </skos:Collection>
+  <skos:Collection rdf:about="http://www.w3.org/ns/odrl/2/#actions">
+    <skos:member>
+      <skos:Concept rdf:about="http://www.w3.org/ns/odrl/2/use">
+        <skos:definition xml:lang="en">To use the Asset</skos:definition>
+        <skos:note xml:lang="en">Use is the most generic action for all non-third-party usage. More specific types of the use action can be expressed by more targetted actions.</skos:note>
+        <rdf:type rdf:resource="http://www.w3.org/ns/odrl/2/Action"/>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <rdfs:label xml:lang="en">Use</rdfs:label>
+      </skos:Concept>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://www.w3.org/ns/odrl/2/transfer">
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <rdf:type rdf:resource="http://www.w3.org/ns/odrl/2/Action"/>
+        <rdfs:label xml:lang="en">Transfer Ownership</rdfs:label>
+        <skos:definition xml:lang="en">To transfer the ownership of the Asset in perpetuity.</skos:definition>
+      </skos:Concept>
+    </skos:member>
+    <skos:prefLabel xml:lang="en">Actions for Rules</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">ODRL Core Vocabulary Terms</skos:scopeNote>
+  </skos:Collection>
+  <owl:Thing rdf:about="http://www.w3.org/ns/odrl/2/core">
+    <skos:definition xml:lang="en">Identifier for the ODRL Core Profile</skos:definition>
+    <rdfs:isDefinedBy>
+      <owl:Ontology rdf:about="http://www.w3.org/ns/odrl/2/">
+        <dct:contributor>W3C Permissions &amp; Obligations Expression Working Group</dct:contributor>
+        <dct:creator>Mo McRoberts</dct:creator>
+        <dct:creator>Stuart Myles</dct:creator>
+        <owl:versionInfo>2.2</owl:versionInfo>
+        <rdfs:comment xml:lang="en">This is the RDF ontology for ODRL Version 2.2 (working draft).</rdfs:comment>
+        <dct:creator>Renato Iannella</dct:creator>
+        <dct:license rdf:resource="https://www.w3.org/Consortium/Legal/2002/ipr-notice-20021231#Copyright/"/>
+        <rdfs:label xml:lang="en">ODRL Version 2.2</rdfs:label>
+        <dct:creator>Michael Steidl</dct:creator>
+        <dct:description xml:lang="en">The ODRL Vocabulary and Expression defines a set of concepts and terms (the vocabulary) and encoding mechanism (the expression) for permissions and obligations statements describing digital content usage based on the ODRL Information Model.</dct:description>
+        <dct:creator>Víctor Rodríguez-Doncel</dct:creator>
+      </owl:Ontology>
+    </rdfs:isDefinedBy>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <rdfs:label xml:lang="en">ODRL Core Profile</rdfs:label>
+  </owl:Thing>
+  <owl:AnnotationProperty rdf:about="http://purl.org/dc/terms/license">
+    <rdfs:subPropertyOf rdf:resource="http://www.w3.org/ns/odrl/2/hasPolicy"/>
+  </owl:AnnotationProperty>
+  <skos:Collection rdf:about="http://www.w3.org/ns/odrl/2/#policySubClasses">
+    <skos:member rdf:resource="http://www.w3.org/ns/odrl/2/Set"/>
+    <skos:scopeNote xml:lang="en">ODRL Core Vocabulary Terms</skos:scopeNote>
+    <skos:member rdf:resource="http://www.w3.org/ns/odrl/2/Agreement"/>
+    <skos:prefLabel xml:lang="en">Policy Subclasses</skos:prefLabel>
+    <skos:member rdf:resource="http://www.w3.org/ns/odrl/2/Offer"/>
+  </skos:Collection>
+  <owl:AnnotationProperty rdf:about="http://purl.org/dc/terms/format"/>
+  <skos:Collection rdf:about="http://www.w3.org/ns/odrl/2/#permissions">
+    <skos:scopeNote xml:lang="en">ODRL Core Vocabulary Terms</skos:scopeNote>
+    <skos:member rdf:resource="http://www.w3.org/ns/odrl/2/Permission"/>
+    <skos:prefLabel xml:lang="en">Permission</skos:prefLabel>
+    <skos:member>
+      <rdf:Property rdf:about="http://www.w3.org/ns/odrl/2/permission">
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <skos:definition xml:lang="en">Relates an individual Permission to a Policy.</skos:definition>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <rdfs:domain rdf:resource="http://www.w3.org/ns/odrl/2/Policy"/>
+        <rdfs:range rdf:resource="http://www.w3.org/ns/odrl/2/Permission"/>
+        <rdfs:label xml:lang="en">Has Permission</rdfs:label>
+      </rdf:Property>
+    </skos:member>
+  </skos:Collection>
+  <skos:Collection rdf:about="http://www.w3.org/ns/odrl/2/#logicalConstraints">
+    <skos:member>
+      <skos:Concept rdf:about="http://www.w3.org/ns/odrl/2/operand">
+        <rdfs:label xml:lang="en">Operand</rdfs:label>
+        <skos:note xml:lang="en">Sub-properties of operand are used for Logical Constraints.</skos:note>
+        <rdfs:domain rdf:resource="http://www.w3.org/ns/odrl/2/LogicalConstraint"/>
+        <skos:definition xml:lang="en">Operand is an abstract property for a logical relationship.</skos:definition>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+      </skos:Concept>
+    </skos:member>
+    <skos:scopeNote xml:lang="en">ODRL Core Vocabulary Terms</skos:scopeNote>
+    <skos:prefLabel xml:lang="en">Logical Constraint</skos:prefLabel>
+    <skos:member rdf:resource="http://www.w3.org/ns/odrl/2/LogicalConstraint"/>
+  </skos:Collection>
+  <owl:AnnotationProperty rdf:about="http://www.w3.org/2004/02/skos/core#note"/>
+  <owl:AnnotationProperty rdf:about="http://purl.org/dc/terms/contributor"/>
+  <skos:Collection rdf:about="http://www.w3.org/ns/odrl/2/#actionConcepts">
+    <skos:prefLabel xml:lang="en">Action</skos:prefLabel>
+    <skos:member>
+      <rdf:Property rdf:about="http://www.w3.org/ns/odrl/2/includedIn">
+        <rdfs:range rdf:resource="http://www.w3.org/ns/odrl/2/Action"/>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <rdfs:domain rdf:resource="http://www.w3.org/ns/odrl/2/Action"/>
+        <skos:note xml:lang="en">The purpose is to explicitly assert that the semantics of the referenced instance of an other Action encompasses (includes) the semantics of this instance of Action. The includedIn property is transitive, and as such, the Actions form ancestor relationships.</skos:note>
+        <rdfs:label xml:lang="en">Included In</rdfs:label>
+        <skos:definition xml:lang="en">An Action transitively asserts that another Action that encompasses its operational semantics.</skos:definition>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#SymmetricProperty"/>
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+      </rdf:Property>
+    </skos:member>
+    <skos:scopeNote xml:lang="en">ODRL Core Vocabulary Terms</skos:scopeNote>
+    <skos:member>
+      <rdf:Property rdf:about="http://www.w3.org/ns/odrl/2/implies">
+        <rdfs:domain rdf:resource="http://www.w3.org/ns/odrl/2/Action"/>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+        <rdfs:label xml:lang="en">Implies</rdfs:label>
+        <skos:note xml:lang="en">The property asserts that an instance of Action entails that the other instance of Action is not prohibited.</skos:note>
+        <rdfs:range rdf:resource="http://www.w3.org/ns/odrl/2/Action"/>
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <skos:definition xml:lang="en">An Action asserts that another Action is not prohibited to enable its operational semantics.</skos:definition>
+      </rdf:Property>
+    </skos:member>
+    <skos:member>
+      <skos:Concept rdf:about="http://www.w3.org/ns/odrl/2/action">
+        <rdfs:domain>
+          <owl:Class rdf:nodeID="ub1bL730C14">
+            <owl:unionOf rdf:parseType="Collection">
+              <rdf:Description rdf:about="http://www.w3.org/ns/odrl/2/Rule"/>
+              <rdf:Description rdf:about="http://www.w3.org/ns/odrl/2/Policy"/>
+            </owl:unionOf>
+          </owl:Class>
+        </rdfs:domain>
+        <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+        <rdfs:label xml:lang="en">Has Action</rdfs:label>
+        <rdfs:range rdf:resource="http://www.w3.org/ns/odrl/2/Action"/>
+        <skos:definition xml:lang="en">The operation relating to the Asset for which the Rule is being subjected.</skos:definition>
+      </skos:Concept>
+    </skos:member>
+    <skos:member rdf:resource="http://www.w3.org/ns/odrl/2/Action"/>
+  </skos:Collection>
+  <owl:AnnotationProperty rdf:about="http://www.w3.org/2004/02/skos/core#member"/>
+  <owl:AnnotationProperty rdf:about="http://purl.org/dc/terms/creator"/>
+  <owl:AnnotationProperty rdf:about="http://purl.org/dc/terms/description"/>
+  <owl:AnnotationProperty rdf:about="http://www.w3.org/2004/02/skos/core#definition"/>
+  <skos:Collection rdf:about="http://www.w3.org/ns/odrl/2/#assetConcepts">
+    <skos:member rdf:resource="http://www.w3.org/ns/odrl/2/AssetCollection"/>
+    <skos:member rdf:resource="http://www.w3.org/ns/odrl/2/partOf"/>
+    <skos:member rdf:resource="http://www.w3.org/ns/odrl/2/source"/>
+    <skos:prefLabel xml:lang="en">Asset</skos:prefLabel>
+    <skos:member rdf:resource="http://www.w3.org/ns/odrl/2/Asset"/>
+    <skos:scopeNote xml:lang="en">ODRL Core Vocabulary Terms</skos:scopeNote>
+  </skos:Collection>
+  <owl:AnnotationProperty rdf:about="http://purl.org/dc/terms/isVersionOf"/>
+  <owl:AnnotationProperty rdf:about="http://purl.org/dc/terms/subject"/>
+  <owl:AnnotationProperty rdf:about="http://www.w3.org/2004/02/skos/core#hasTopConcept"/>
+  <owl:AnnotationProperty rdf:about="http://www.w3.org/2004/02/skos/core#prefLabel"/>
+  <owl:AnnotationProperty rdf:about="http://www.w3.org/2004/02/skos/core#scopeNote"/>
+  <owl:AnnotationProperty rdf:about="http://purl.org/dc/terms/issued"/>
+  <owl:Class rdf:about="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
+  <owl:AnnotationProperty rdf:about="http://www.w3.org/2004/02/skos/core#broaderTransitive"/>
+  <owl:AnnotationProperty rdf:about="http://www.w3.org/2004/02/skos/core#broader"/>
+  <skos:Concept rdf:about="http://www.w3.org/ns/odrl/2/Assertion">
+    <owl:disjointWith rdf:resource="http://www.w3.org/ns/odrl/2/Privacy"/>
+    <skos:note xml:lang="en">For example, a party (an assignee or assigner) can claim what terms they have over an Asset. An Assertion Policy does not grant such permissions/prohibitions but only asserts the parties claims. An Assetion Policy  MUST contain a target Asset, a Party with any functional role, and at least one of a Permission or Prohibition rule.</skos:note>
+    <skos:definition xml:lang="en">A Policy that asserts a Rule over an Asset from parties.</skos:definition>
+    <rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
+    <rdfs:subClassOf rdf:resource="http://www.w3.org/ns/odrl/2/Policy"/>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <owl:disjointWith rdf:resource="http://www.w3.org/ns/odrl/2/Offer"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <owl:disjointWith rdf:resource="http://www.w3.org/ns/odrl/2/Ticket"/>
+    <owl:disjointWith rdf:resource="http://www.w3.org/ns/odrl/2/Set"/>
+    <skos:scopeNote xml:lang="en">Non-Normative</skos:scopeNote>
+    <owl:disjointWith rdf:resource="http://www.w3.org/ns/odrl/2/Request"/>
+    <rdfs:label xml:lang="en">Assertion</rdfs:label>
+  </skos:Concept>
+  <rdfs:Class rdf:about="http://www.w3.org/ns/odrl/2/Prohibition">
+    <owl:disjointWith rdf:resource="http://www.w3.org/ns/odrl/2/Permission"/>
+    <owl:disjointWith rdf:resource="http://www.w3.org/ns/odrl/2/Duty"/>
+    <rdfs:subClassOf rdf:resource="http://www.w3.org/ns/odrl/2/Rule"/>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <rdfs:label xml:lang="en">Prohibition</rdfs:label>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <skos:definition xml:lang="en">The inability to perform an Action over an Asset.</skos:definition>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdfs:Class>
+  <owl:Class rdf:about="http://www.w3.org/ns/odrl/2/LogicalConstraint">
+    <skos:definition xml:lang="en">A logical expression that refines the semantics of an Action and Party/Asset Collection or declare the conditions applicable to a Rule.</skos:definition>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <rdfs:label xml:lang="en">Logical Constraint</rdfs:label>
+  </owl:Class>
+  <skos:Concept rdf:about="http://www.w3.org/ns/odrl/2/Party">
+    <rdfs:label xml:lang="en">Party</rdfs:label>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <skos:definition xml:lang="en">An entity or a collection of entities that undertake Roles in a Rule.</skos:definition>
+    <rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
+    <skos:note xml:lang="en">The Party entity could be a person, group of people, organisation, or agent. An agent is a person or thing that takes an active role or produces a specified effect. To describe more details about the Party, it is recommended to use W3C vCard Ontology [[vcard-rdf]] or FOAF Vocabulary [[foaf]].</skos:note>
+    <rdfs:subClassOf>
+      <owl:Class rdf:nodeID="ub1bL419C18">
+        <owl:unionOf rdf:parseType="Collection">
+          <rdf:Description rdf:about="http://schema.org/Person"/>
+          <rdf:Description rdf:about="http://schema.org/Organization"/>
+          <rdf:Description rdf:about="http://xmlns.com/foaf/0.1/Person"/>
+          <rdf:Description rdf:about="http://xmlns.com/foaf/0.1/Organization"/>
+          <rdf:Description rdf:about="http://xmlns.com/foaf/0.1/Agent"/>
+          <rdf:Description rdf:about="http://www.w3.org/2006/vcard/ns#Individual"/>
+          <rdf:Description rdf:about="http://www.w3.org/2006/vcard/ns#Organization"/>
+          <rdf:Description rdf:about="http://www.w3.org/2006/vcard/ns#Agent"/>
+        </owl:unionOf>
+      </owl:Class>
+    </rdfs:subClassOf>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </skos:Concept>
+  <rdfs:Class rdf:about="http://www.w3.org/ns/odrl/2/Set">
+    <owl:disjointWith rdf:resource="http://www.w3.org/ns/odrl/2/Assertion"/>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <owl:disjointWith rdf:resource="http://www.w3.org/ns/odrl/2/Request"/>
+    <owl:disjointWith rdf:resource="http://www.w3.org/ns/odrl/2/Ticket"/>
+    <rdfs:subClassOf rdf:resource="http://www.w3.org/ns/odrl/2/Policy"/>
+    <owl:disjointWith rdf:resource="http://www.w3.org/ns/odrl/2/Agreement"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <skos:definition xml:lang="en">A Policy that expresses a Rule over an Asset.</skos:definition>
+    <owl:disjointWith rdf:resource="http://www.w3.org/ns/odrl/2/Privacy"/>
+    <owl:disjointWith rdf:resource="http://www.w3.org/ns/odrl/2/Offer"/>
+    <rdfs:label xml:lang="en">Set</rdfs:label>
+    <skos:note xml:lang="en">A Set Policy MUST contain a target Asset, and at least one Rule. A Set Policy is the default Policy subclass. The Set is aimed at scenarios where there is an open criteria for the semantics of the policy expressions and typically refined by other systems/profiles that process the information at a later time. No privileges are granted to any Party (if defined).</skos:note>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdfs:Class>
+  <rdfs:Class rdf:about="http://www.w3.org/ns/odrl/2/Ticket">
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <owl:disjointWith rdf:resource="http://www.w3.org/ns/odrl/2/Set"/>
+    <skos:scopeNote xml:lang="en">Non-Normative</skos:scopeNote>
+    <owl:disjointWith rdf:resource="http://www.w3.org/ns/odrl/2/Request"/>
+    <skos:definition xml:lang="en">A Policy that grants the holder a Rule over an Asset from an assigner.</skos:definition>
+    <owl:disjointWith rdf:resource="http://www.w3.org/ns/odrl/2/Assertion"/>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:note xml:lang="en">A Ticket Policy MUST contain a target Asset and at least one of a Permission or Prohibition rule.  The Ticket MAY contain the Party with Assigner function and MUST NOT contain an Assignee. The Ticket Policy will grant the terms of the Policy to the holder of that Ticket. The holder of the Ticket MAY remain unknown or MAY have to be identified at some later stage.</skos:note>
+    <rdfs:subClassOf rdf:resource="http://www.w3.org/ns/odrl/2/Policy"/>
+    <owl:disjointWith rdf:resource="http://www.w3.org/ns/odrl/2/Offer"/>
+    <owl:disjointWith rdf:resource="http://www.w3.org/ns/odrl/2/Privacy"/>
+    <rdfs:label xml:lang="en">Ticket</rdfs:label>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <owl:disjointWith rdf:resource="http://www.w3.org/ns/odrl/2/Agreement"/>
+  </rdfs:Class>
+  <owl:Class rdf:about="http://www.w3.org/ns/odrl/2/Action">
+    <rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
+    <rdfs:label xml:lang="en">Action</rdfs:label>
+    <skos:definition xml:lang="en">An operation on an Asset.</skos:definition>
+    <rdfs:subClassOf rdf:resource="http://schema.org/Action"/>
+    <skos:note xml:lang="en">Actions may be allowed by Permissions, disallowed by Prohibitions, or made mandatory by Duties.</skos:note>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+  </owl:Class>
+  <rdfs:Class rdf:about="http://www.w3.org/ns/odrl/2/Operator">
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <skos:note xml:lang="en">Instances of the Operator class representing relational operators.</skos:note>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:definition xml:lang="en">Operator for constraint expression.</skos:definition>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <rdfs:label xml:lang="en">Operator</rdfs:label>
+  </rdfs:Class>
+  <skos:Concept rdf:about="http://www.w3.org/ns/odrl/2/Offer">
+    <owl:disjointWith rdf:resource="http://www.w3.org/ns/odrl/2/Agreement"/>
+    <rdfs:subClassOf rdf:resource="http://www.w3.org/ns/odrl/2/Policy"/>
+    <skos:note xml:lang="en">An Offer Policy MUST contain at least one Permission or Prohibition rule and a Party with Assigner function (in the same Permission or Prohibition). The Offer Policy MAY contain a Party with Assignee function, but MUST not grant any privileges to that Party.</skos:note>
+    <owl:disjointWith rdf:resource="http://www.w3.org/ns/odrl/2/Privacy"/>
+    <skos:definition xml:lang="en">A Policy that proposes a Rule over an Asset from an assigner.</skos:definition>
+    <owl:disjointWith rdf:resource="http://www.w3.org/ns/odrl/2/Set"/>
+    <rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
+    <rdfs:label xml:lang="en">Offer</rdfs:label>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <owl:disjointWith rdf:resource="http://www.w3.org/ns/odrl/2/Request"/>
+    <owl:disjointWith rdf:resource="http://www.w3.org/ns/odrl/2/Assertion"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <owl:disjointWith rdf:resource="http://www.w3.org/ns/odrl/2/Ticket"/>
+  </skos:Concept>
+  <owl:Class rdf:about="http://www.w3.org/ns/odrl/2/AssetCollection">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <skos:definition xml:lang="en">An Asset that is collection of individual resources</skos:definition>
+    <rdfs:label xml:lang="en">Asset Collection</rdfs:label>
+    <rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
+    <rdfs:subClassOf rdf:resource="http://www.w3.org/ns/odrl/2/Asset"/>
+  </owl:Class>
+  <owl:Class rdf:about="http://www.w3.org/ns/odrl/2/AssetScope">
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+    <skos:definition xml:lang="en">Scopes for Asset Scope expressions.</skos:definition>
+    <rdfs:label xml:lang="en">Asset Scope</rdfs:label>
+    <rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:note xml:lang="en">Instances of the AssetScope class represent the terms for the scope property of Assets.</skos:note>
+  </owl:Class>
+  <rdfs:Class rdf:about="http://www.w3.org/ns/odrl/2/Request">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <rdfs:subClassOf rdf:resource="http://www.w3.org/ns/odrl/2/Policy"/>
+    <owl:disjointWith rdf:resource="http://www.w3.org/ns/odrl/2/Agreement"/>
+    <owl:disjointWith rdf:resource="http://www.w3.org/ns/odrl/2/Offer"/>
+    <skos:definition xml:lang="en">A Policy that proposes a Rule over an Asset from an assignee.</skos:definition>
+    <owl:disjointWith rdf:resource="http://www.w3.org/ns/odrl/2/Privacy"/>
+    <owl:disjointWith rdf:resource="http://www.w3.org/ns/odrl/2/Set"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <skos:note xml:lang="en">A Request Policy  MUST contain a target Asset, a Party with Assignee function, and at least one of a Permission or Prohibition rule. The Request MAY also contain the Party with Assigner function if this is known. No privileges are granted to any Party.</skos:note>
+    <skos:scopeNote xml:lang="en">Non-Normative</skos:scopeNote>
+    <rdfs:label xml:lang="en">Request</rdfs:label>
+    <owl:disjointWith rdf:resource="http://www.w3.org/ns/odrl/2/Ticket"/>
+    <owl:disjointWith rdf:resource="http://www.w3.org/ns/odrl/2/Assertion"/>
+  </rdfs:Class>
+  <skos:Concept rdf:about="http://www.w3.org/ns/odrl/2/LeftOperand">
+    <skos:note xml:lang="en">Instances of the LeftOperand class are used as the leftOperand of a Constraint.</skos:note>
+    <rdfs:label xml:lang="en">Left Operand</rdfs:label>
+    <rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <skos:definition xml:lang="en">Left operand for constraint expression.</skos:definition>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://www.w3.org/ns/odrl/2/UndefinedTerm">
+    <skos:note xml:lang="en">Instances of UndefinedTerm describe strategies for processing unsupported actions.</skos:note>
+    <rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
+    <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">Undefined Term</rdfs:label>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <skos:definition xml:lang="en">Is used to indicate how to support Actions that are not part of any vocabulary or profile in the policy expression system.</skos:definition>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://www.w3.org/ns/odrl/2/Agreement">
+    <owl:disjointWith rdf:resource="http://www.w3.org/ns/odrl/2/Offer"/>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <skos:definition xml:lang="en">A Policy that grants the assignee a Rule over an Asset from an assigner.</skos:definition>
+    <owl:disjointWith rdf:resource="http://www.w3.org/ns/odrl/2/Assertion"/>
+    <rdfs:subClassOf rdf:resource="http://www.w3.org/ns/odrl/2/Policy"/>
+    <rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
+    <owl:disjointWith rdf:resource="http://www.w3.org/ns/odrl/2/Request"/>
+    <owl:disjointWith rdf:resource="http://www.w3.org/ns/odrl/2/Privacy"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <rdfs:label xml:lang="en">Agreement</rdfs:label>
+    <skos:note xml:lang="en">An Agreement Policy MUST contain at least one Permission or Prohibition rule, a Party with Assigner function, and a Party with Assignee function (in the same Permission or Prohibition). The Agreement Policy will grant the terms of the Policy from the Assigner to the Assignee.</skos:note>
+    <owl:disjointWith rdf:resource="http://www.w3.org/ns/odrl/2/Ticket"/>
+    <owl:disjointWith rdf:resource="http://www.w3.org/ns/odrl/2/Set"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://www.w3.org/ns/odrl/2/Privacy">
+    <owl:disjointWith rdf:resource="http://www.w3.org/ns/odrl/2/Assertion"/>
+    <owl:disjointWith rdf:resource="http://www.w3.org/ns/odrl/2/Request"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <owl:disjointWith rdf:resource="http://www.w3.org/ns/odrl/2/Offer"/>
+    <skos:definition xml:lang="en">A Policy that expresses a Rule over an Asset containing personal information.</skos:definition>
+    <skos:scopeNote xml:lang="en">Non-Normative</skos:scopeNote>
+    <rdfs:label xml:lang="en">Privacy Policy</rdfs:label>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <owl:disjointWith rdf:resource="http://www.w3.org/ns/odrl/2/Agreement"/>
+    <owl:disjointWith rdf:resource="http://www.w3.org/ns/odrl/2/Set"/>
+    <skos:note xml:lang="en">A Privacy Policy  MUST contain a target Asset, a Party with Assigner  is, a Party with Assignee function, and at least one of a Permission or Prohibition rule that MUST include a Duty. The target Asset SHOULD contain or relate to personal information about the Assignee. The Duty MUST describe obligations on the Assigner about managing the Asset. The Assignee is being granted the terms of the Privacy policy from the Assigner.</skos:note>
+    <rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
+    <rdfs:subClassOf rdf:resource="http://www.w3.org/ns/odrl/2/Policy"/>
+    <owl:disjointWith rdf:resource="http://www.w3.org/ns/odrl/2/Ticket"/>
+  </skos:Concept>
+  <rdfs:Class rdf:about="http://www.w3.org/ns/odrl/2/PartyCollection">
+    <rdfs:subClassOf rdf:resource="http://www.w3.org/ns/odrl/2/Party"/>
+    <skos:definition xml:lang="en">A Party that is a group of individual entities</skos:definition>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <rdfs:label xml:lang="en">Party Collection</rdfs:label>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdfs:Class>
+  <rdfs:Class rdf:about="http://www.w3.org/ns/odrl/2/Rule">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <skos:note xml:lang="en">Rule is an abstract concept.</skos:note>
+    <rdfs:label xml:lang="en">Rule</rdfs:label>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <skos:definition xml:lang="en">An abstract concept that represents the common characteristics of Permissions, Prohibitions, and Duties.</skos:definition>
+  </rdfs:Class>
+  <skos:Concept rdf:about="http://www.w3.org/ns/odrl/2/Constraint">
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
+    <rdfs:label xml:lang="en">Constraint</rdfs:label>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <skos:definition xml:lang="en">A boolean expression that refines the semantics of an Action and Party/Asset Collection or declare the conditions applicable to a Rule.</skos:definition>
+  </skos:Concept>
+  <owl:Class rdf:about="http://www.w3.org/ns/odrl/2/Policy">
+    <skos:note xml:lang="en">A Policy may contain multiple Rules.</skos:note>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <skos:definition xml:lang="en">A non-empty group of Permissions and/or Prohibitions.</skos:definition>
+    <rdfs:label xml:lang="en">Policy</rdfs:label>
+    <rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
+  </owl:Class>
+  <skos:Concept rdf:about="http://www.w3.org/ns/odrl/2/ConflictTerm">
+    <skos:definition xml:lang="en">Used to establish strategies to resolve conflicts that arise from the merging of Policies or conflicts between Permissions and Prohibitions in the same Policy.</skos:definition>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <rdfs:label xml:lang="en">Conflict Strategy Preference</rdfs:label>
+    <rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <skos:note xml:lang="en">Instances of ConflictTerm describe strategies for resolving conflicts.</skos:note>
+  </skos:Concept>
+  <rdfs:Class rdf:about="http://www.w3.org/ns/odrl/2/Duty">
+    <skos:definition xml:lang="en">The obligation to perform an Action</skos:definition>
+    <owl:disjointWith rdf:resource="http://www.w3.org/ns/odrl/2/Permission"/>
+    <owl:disjointWith rdf:resource="http://www.w3.org/ns/odrl/2/Prohibition"/>
+    <rdfs:subClassOf rdf:resource="http://www.w3.org/ns/odrl/2/Rule"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <rdfs:label xml:lang="en">Duty</rdfs:label>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdfs:Class>
+  <owl:Class rdf:about="http://www.w3.org/ns/odrl/2/Permission">
+    <rdfs:subClassOf rdf:resource="http://www.w3.org/ns/odrl/2/Rule"/>
+    <owl:disjointWith rdf:resource="http://www.w3.org/ns/odrl/2/Duty"/>
+    <rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
+    <owl:disjointWith rdf:resource="http://www.w3.org/ns/odrl/2/Prohibition"/>
+    <rdfs:label xml:lang="en">Permission</rdfs:label>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:definition xml:lang="en">The ability to perform an Action over an Asset.</skos:definition>
+  </owl:Class>
+  <owl:Class rdf:about="http://www.w3.org/2004/02/skos/core#Collection"/>
+  <owl:Class rdf:about="http://www.w3.org/ns/odrl/2/Asset">
+    <skos:definition xml:lang="en">A resource or a collection of resources that are the subject of a Rule.</skos:definition>
+    <rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <rdfs:label xml:lang="en">Asset</rdfs:label>
+    <skos:note xml:lang="en">The Asset entity can be any form of identifiable resource, such as data/information, content/media, applications, or services. Furthermore, it can be used to represent other Asset entities that are needed to undertake the Policy expression, such as with the Duty entity. To describe more details about the Asset, it is recommended to use Dublin Core [[dcterms]] elements or other content metadata.</skos:note>
+  </owl:Class>
+  <rdfs:Class rdf:about="http://www.w3.org/ns/odrl/2/PartyScope">
+    <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+    <rdfs:label xml:lang="en">Party Scope</rdfs:label>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <skos:note xml:lang="en">Instances of the PartyScope class represent the terms for the scope property of Parties.</skos:note>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:definition xml:lang="en">Scopes for Party Scope expressions.</skos:definition>
+  </rdfs:Class>
+  <owl:Class rdf:about="http://www.w3.org/ns/odrl/2/RightOperand">
+    <skos:definition xml:lang="en">Right operand for constraint expression.</skos:definition>
+    <rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
+    <rdfs:label xml:lang="en">Right Operand</rdfs:label>
+    <skos:note xml:lang="en">Instances of the RightOperand class are used as the rightOperand of a Constraint.</skos:note>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+  </owl:Class>
+  <owl:Class rdf:about="http://www.w3.org/2004/02/skos/core#Concept"/>
+</rdf:RDF>
+


### PR DESCRIPTION
- The ODRL22.nt and ODRL22.rdf files were empty; I have copied .ttl to .nt, and used a separate program to generate the RDF/XML version
- Added an ODRL22.html file that refers to the official specs

I have also uploaded these to /ns, and the redirections are now working properly.